### PR TITLE
[BUGFIX] correctly emitting calls with addressoff operator

### DIFF
--- a/tools/cgeist/Lib/clang-mlir.cc
+++ b/tools/cgeist/Lib/clang-mlir.cc
@@ -1545,6 +1545,10 @@ const clang::FunctionDecl *MLIRScanner::EmitCallee(const Expr *E) {
     // Look through template substitutions.
   } else if (auto NTTP = dyn_cast<SubstNonTypeTemplateParmExpr>(E)) {
     return EmitCallee(NTTP->getReplacement());
+  } else if (auto UOp = dyn_cast<clang::UnaryOperator>(E)) {
+    if (UOp->getOpcode() == UnaryOperatorKind::UO_AddrOf) {
+      return EmitCallee(UOp->getSubExpr());
+    }
   }
 
   return nullptr;

--- a/tools/cgeist/Test/addressoff_call.cpp
+++ b/tools/cgeist/Test/addressoff_call.cpp
@@ -1,0 +1,19 @@
+// RUN: cgeist %s --function=_Z1fv -S | FileCheck %s
+unsigned long foo(unsigned);
+inline unsigned long inlineFunc(unsigned i) noexcept {
+  return foo(i);
+}
+
+struct S {
+  static unsigned long bar() noexcept {
+    return (&inlineFunc)(0);
+  }
+};
+
+void f(){
+  auto res = S::bar();
+}
+// CHECK: func.func @_Z10inlineFuncj(%arg0: i32) -> i64 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:   %0 = call @_Z3fooj(%arg0) : (i32) -> i64
+// CHECK-NEXT:   return %0 : i64
+// CHECK-NEXT: }


### PR DESCRIPTION
This will allow to correctly emit function calls when the AST contains operator & nodes.