### PR TITLE
WIP: alternative lowering for memrefs

### DIFF
--- a/include/polygeist/Passes/Passes.td
+++ b/include/polygeist/Passes/Passes.td
@@ -130,7 +130,11 @@ def ConvertPolygeistToLLVM : Pass<"convert-polygeist-to-llvm", "mlir::ModuleOp">
     Option<"dataLayout", "data-layout", "std::string",
            /*default=*/"\"\"",
            "String description (LLVM format) of the data layout that is "
-           "expected on the produced module">
+           "expected on the produced module">,
+    Option<"useCStyleMemRef", "use-c-style-memref", "bool",
+           /*default=*/"true",
+           "Use C-style nested-array lowering of memref instead of "
+           "the default MLIR descriptor structure">
   ];
 }
 

--- a/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h"
@@ -24,8 +25,10 @@
 #include "mlir/Dialect/Async/IR/Async.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BlockAndValueMapping.h"
@@ -624,7 +627,581 @@ struct ReturnOpTypeConversion : public ConvertOpToLLVMPattern<LLVM::ReturnOp> {
     return success();
   }
 };
+} // namespace
 
+//===-----------------------------------------------------------------------===/
+// Patterns for C-compatible MemRef lowering.
+//===-----------------------------------------------------------------------===/
+// Additional patterns for converting MLIR ops from MemRef and Func dialects
+// to the LLVM dialect using the C-compatible type conversion for memrefs.
+// Specifically, a memref such as memref<A x B x C x type> is converted into
+// a pointer to an array of arrays such as !llvm.ptr<array<B x array<C x type>>
+// with additional conversion of the element type. This approach is only
+// applicable to memrefs with static shapes in all dimensions but the outermost,
+// which coincides with the nested array constructs allowed in C (except VLA).
+// This also matches the type produced by Clang for such array constructs,
+// removing the need for ABI compatibility layers.
+//===-----------------------------------------------------------------------===/
+
+namespace {
+/// Pattern for allocation-like operations.
+template <typename OpTy>
+struct AllocLikeOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+public:
+  using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
+
+protected:
+  /// Returns the value containing the outermost dimension of the memref to be
+  /// allocated, or 1 if the memref has rank zero.
+  Value getOuterSize(OpTy original,
+                     typename ConvertOpToLLVMPattern<OpTy>::OpAdaptor adaptor,
+                     ConversionPatternRewriter &rewriter) const {
+    if (!adaptor.getDynamicSizes().empty())
+      return adaptor.getDynamicSizes().front();
+
+    return this->createIndexConstant(rewriter, original->getLoc(),
+                                     original.getType().getRank() == 0
+                                         ? 1
+                                         : original.getType().getDimSize(0));
+  }
+};
+
+/// Pattern for lowering automatic stack allocations.
+struct AllocaOpLowering : public AllocLikeOpLowering<memref::AllocaOp> {
+public:
+  using AllocLikeOpLowering<memref::AllocaOp>::AllocLikeOpLowering;
+
+  LogicalResult
+  matchAndRewrite(memref::AllocaOp allocaOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = allocaOp.getLoc();
+    MemRefType originalType = allocaOp.getType();
+    auto convertedType = getTypeConverter()
+                             ->convertType(originalType)
+                             .dyn_cast_or_null<LLVM::LLVMPointerType>();
+    if (!convertedType)
+      return rewriter.notifyMatchFailure(loc, "unsupported memref type");
+
+    assert(adaptor.getDynamicSizes().size() <= 1 &&
+           "expected at most one dynamic size");
+
+    Value outerSize = getOuterSize(allocaOp, adaptor, rewriter);
+    rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
+        allocaOp, convertedType, outerSize, adaptor.getAlignment().value_or(0));
+    return success();
+  }
+};
+
+/// Pattern for lowering heap allocations via malloc.
+struct AllocOpLowering : public AllocLikeOpLowering<memref::AllocOp> {
+public:
+  using AllocLikeOpLowering<memref::AllocOp>::AllocLikeOpLowering;
+
+  LogicalResult
+  matchAndRewrite(memref::AllocOp allocOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = allocOp.getLoc();
+    MemRefType originalType = allocOp.getType();
+    auto convertedType = getTypeConverter()
+                             ->convertType(originalType)
+                             .dyn_cast_or_null<LLVM::LLVMPointerType>();
+    if (!convertedType)
+      return rewriter.notifyMatchFailure(loc, "unsupported memref type");
+    if (adaptor.alignment() && adaptor.alignment().value() != 0)
+      return rewriter.notifyMatchFailure(loc, "unsupported alignment");
+
+    Value outerSize = getOuterSize(allocOp, adaptor, rewriter);
+    Value null = rewriter.create<LLVM::NullOp>(loc, convertedType);
+    auto next =
+        rewriter.create<LLVM::GEPOp>(loc, convertedType, null, LLVM::GEPArg(1));
+    Value elementSize =
+        rewriter.create<LLVM::PtrToIntOp>(loc, getIndexType(), next);
+    Value size = rewriter.create<LLVM::MulOp>(loc, outerSize, elementSize);
+
+    auto module = allocOp->getParentOfType<ModuleOp>();
+    LLVM::LLVMFuncOp mallocFunc =
+        getTypeConverter()->getOptions().useGenericFunctions
+            ? LLVM::lookupOrCreateGenericAllocFn(module, getIndexType())
+            : LLVM::lookupOrCreateMallocFn(module, getIndexType());
+    Value allocated =
+        rewriter.create<LLVM::CallOp>(loc, mallocFunc, size).getResult();
+    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(allocOp, convertedType,
+                                                 allocated);
+    return success();
+  }
+};
+
+/// Pattern for lowering heap deallocations via free.
+struct DeallocOpLowering : public ConvertOpToLLVMPattern<memref::DeallocOp> {
+public:
+  using ConvertOpToLLVMPattern<memref::DeallocOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::DeallocOp deallocOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto module = deallocOp->getParentOfType<ModuleOp>();
+    LLVM::LLVMFuncOp freeFunc =
+        getTypeConverter()->getOptions().useGenericFunctions
+            ? LLVM::lookupOrCreateGenericFreeFn(module)
+            : LLVM::lookupOrCreateFreeFn(module);
+    Value casted = rewriter.create<LLVM::BitcastOp>(
+        deallocOp->getLoc(), getVoidPtrType(), adaptor.getMemref());
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(deallocOp, freeFunc, casted);
+    return success();
+  }
+};
+
+/// Converts the given memref type into the LLVM type that can be used for a
+/// global. The memref type must have all dimensions statically known. The
+/// provided type converter is used to convert the elemental type.
+static Type convertGlobalMemRefTypeToLLVM(MemRefType type,
+                                          TypeConverter &typeConverter) {
+  if (!type.hasStaticShape() || !type.getLayout().isIdentity())
+    return nullptr;
+
+  Type convertedType = typeConverter.convertType(type.getElementType());
+  if (!convertedType)
+    return nullptr;
+
+  for (int64_t size : llvm::reverse(type.getShape()))
+    convertedType = LLVM::LLVMArrayType::get(convertedType, size);
+  return convertedType;
+}
+
+/// Pattern for lowering global memref declarations.
+struct GlobalOpLowering : public ConvertOpToLLVMPattern<memref::GlobalOp> {
+public:
+  using ConvertOpToLLVMPattern<memref::GlobalOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::GlobalOp globalOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MemRefType originalType = globalOp.getType();
+    if (!originalType.hasStaticShape() ||
+        !originalType.getLayout().isIdentity()) {
+      return rewriter.notifyMatchFailure(globalOp->getLoc(),
+                                         "unsupported type");
+    }
+
+    Type convertedType =
+        convertGlobalMemRefTypeToLLVM(originalType, *typeConverter);
+    LLVM::Linkage linkage =
+        globalOp.isPublic() ? LLVM::Linkage::External : LLVM::Linkage::Private;
+    if (!convertedType) {
+      return rewriter.notifyMatchFailure(globalOp->getLoc(),
+                                         "failed to convert memref type");
+    }
+
+    Attribute initialValue = nullptr;
+    if (!globalOp.isExternal() && !globalOp.isUninitialized()) {
+      auto elementsAttr = globalOp.getInitialValue()->cast<ElementsAttr>();
+      initialValue = elementsAttr;
+
+      // For scalar memrefs, the global variable created is of the element type,
+      // so unpack the elements attribute to extract the value.
+      if (originalType.getRank() == 0)
+        initialValue = elementsAttr.getSplatValue<Attribute>();
+    }
+
+    uint64_t alignment = globalOp.getAlignment().value_or(0);
+    auto newGlobal = rewriter.replaceOpWithNewOp<LLVM::GlobalOp>(
+        globalOp, convertedType, globalOp.getConstant(), linkage,
+        globalOp.getSymName(), initialValue, alignment,
+        originalType.getMemorySpaceAsInt());
+    if (!globalOp.isExternal() && globalOp.isUninitialized()) {
+      Block *block =
+          rewriter.createBlock(&newGlobal.getInitializerRegion(),
+                               newGlobal.getInitializerRegion().begin());
+      rewriter.setInsertionPointToStart(block);
+      Value undef =
+          rewriter.create<LLVM::UndefOp>(globalOp->getLoc(), convertedType);
+      rewriter.create<LLVM::ReturnOp>(globalOp->getLoc(), undef);
+    }
+    return success();
+  }
+};
+
+/// Pattern for lowering operations taking the address of a global memref.
+struct GetGlobalOpLowering
+    : public ConvertOpToLLVMPattern<memref::GetGlobalOp> {
+public:
+  using ConvertOpToLLVMPattern<memref::GetGlobalOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::GetGlobalOp getGlobalOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MemRefType originalType = getGlobalOp.getType();
+    Type convertedType =
+        convertGlobalMemRefTypeToLLVM(originalType, *typeConverter);
+    Value wholeAddress = rewriter.create<LLVM::AddressOfOp>(
+        getGlobalOp->getLoc(),
+        LLVM::LLVMPointerType::get(convertedType,
+                                   originalType.getMemorySpaceAsInt()),
+        getGlobalOp.getName());
+
+    if (originalType.getRank() == 0) {
+      rewriter.replaceOp(getGlobalOp, wholeAddress);
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
+        getGlobalOp,
+        LLVM::LLVMPointerType::get(
+            convertedType.cast<LLVM::LLVMArrayType>().getElementType(),
+            originalType.getMemorySpaceAsInt()),
+        wholeAddress, SmallVector<LLVM::GEPArg>(/*Size=*/2, /*Value=*/0));
+    return success();
+  }
+};
+
+/// Base class for patterns lowering memory access operations.
+template <typename OpTy>
+struct LoadStoreOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+protected:
+  using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
+
+  /// Emits the IR that computes the address of the memory being accessed.
+  Value getAddress(OpTy op,
+                   typename ConvertOpToLLVMPattern<OpTy>::OpAdaptor adaptor,
+                   ConversionPatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    MemRefType originalType = op.getMemRefType();
+    auto convertedType =
+        this->getTypeConverter()
+            ->convertType(originalType)
+            .template dyn_cast_or_null<LLVM::LLVMPointerType>();
+    if (!convertedType) {
+      (void)rewriter.notifyMatchFailure(loc, "unsupported memref type");
+      return nullptr;
+    }
+
+    SmallVector<LLVM::GEPArg> args = llvm::to_vector(llvm::map_range(
+        adaptor.getIndices(), [](Value v) { return LLVM::GEPArg(v); }));
+    return rewriter.create<LLVM::GEPOp>(
+        loc, this->getElementPtrType(originalType), adaptor.getMemref(), args);
+  }
+};
+
+/// Pattern for lowering a memory load.
+struct LoadOpLowering : public LoadStoreOpLowering<memref::LoadOp> {
+public:
+  using LoadStoreOpLowering<memref::LoadOp>::LoadStoreOpLowering;
+
+  LogicalResult
+  matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value address = getAddress(loadOp, adaptor, rewriter);
+    if (!address)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(loadOp, address);
+    return success();
+  }
+};
+
+/// Pattern for lowering a memory store.
+struct StoreOpLowering : public LoadStoreOpLowering<memref::StoreOp> {
+public:
+  using LoadStoreOpLowering<memref::StoreOp>::LoadStoreOpLowering;
+
+  LogicalResult
+  matchAndRewrite(memref::StoreOp storeOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value address = getAddress(storeOp, adaptor, rewriter);
+    if (!address)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<LLVM::StoreOp>(storeOp, adaptor.getValue(),
+                                               address);
+    return success();
+  }
+};
+} // namespace
+
+/// Only retain those attributes that are not constructed by
+/// `LLVMFuncOp::build`. If `filterArgAttrs` is set, also filter out argument
+/// attributes.
+static void filterFuncAttributes(ArrayRef<NamedAttribute> attrs,
+                                 bool filterArgAndResAttrs,
+                                 SmallVectorImpl<NamedAttribute> &result) {
+  for (const auto &attr : attrs) {
+    if (attr.getName() == SymbolTable::getSymbolAttrName() ||
+        attr.getName() == FunctionOpInterface::getTypeAttrName() ||
+        attr.getName() == "func.varargs" ||
+        (filterArgAndResAttrs &&
+         (attr.getName() == FunctionOpInterface::getArgDictAttrName() ||
+          attr.getName() == FunctionOpInterface::getResultDictAttrName())))
+      continue;
+    result.push_back(attr);
+  }
+}
+
+/// Helper function for wrapping all attributes into a single DictionaryAttr
+static auto wrapAsStructAttrs(OpBuilder &b, ArrayAttr attrs) {
+  return DictionaryAttr::get(
+      b.getContext(),
+      b.getNamedAttr(LLVM::LLVMDialect::getStructAttrsAttrName(), attrs));
+}
+
+static constexpr llvm::StringLiteral kLLVMLinkageAttrName = "llvm.linkage";
+
+/// Convert function argument, operation and result attributes to the LLVM
+/// dialect. This identifies attributes known to contain types and converts
+/// those types using the converter provided. This also accounts for the calling
+/// convention of packing multiple values returned from a function into an
+/// anonymous struct. Adapted from upstream MLIR.
+static SmallVector<NamedAttribute> convertFuncAttributes(
+    func::FuncOp funcOp, TypeConverter &typeConverter,
+    const TypeConverter::SignatureConversion &signatureConversion,
+    OpBuilder &rewriter) {
+  // Propagate argument/result attributes to all converted arguments/result
+  // obtained after converting a given original argument/result.
+  SmallVector<NamedAttribute> attributes;
+  filterFuncAttributes(funcOp->getAttrs(), /*filterArgAndResAttrs=*/true,
+                       attributes);
+  if (ArrayAttr resAttrDicts = funcOp.getAllResultAttrs()) {
+    assert(!resAttrDicts.empty() && "expected array to be non-empty");
+    auto newResAttrDicts =
+        (funcOp.getNumResults() == 1)
+            ? resAttrDicts
+            : rewriter.getArrayAttr(
+                  {wrapAsStructAttrs(rewriter, resAttrDicts)});
+    attributes.push_back(rewriter.getNamedAttr(
+        FunctionOpInterface::getResultDictAttrName(), newResAttrDicts));
+  }
+  if (ArrayAttr argAttrDicts = funcOp.getAllArgAttrs()) {
+    SmallVector<Attribute> newArgAttrs(funcOp.getNumArguments());
+    for (unsigned i = 0, e = funcOp.getNumArguments(); i < e; ++i) {
+      // Some LLVM IR attribute have a type attached to them. During FuncOp ->
+      // LLVMFuncOp conversion these types may have changed. Account for that
+      // change by converting attributes' types as well.
+      SmallVector<NamedAttribute, 4> convertedAttrs;
+      auto attrsDict = argAttrDicts[i].cast<DictionaryAttr>();
+      convertedAttrs.reserve(attrsDict.size());
+      for (const NamedAttribute &attr : attrsDict) {
+        const auto convert = [&](const NamedAttribute &attr) {
+          return TypeAttr::get(typeConverter.convertType(
+              attr.getValue().cast<TypeAttr>().getValue()));
+        };
+        if (attr.getName().getValue() ==
+            LLVM::LLVMDialect::getByValAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getByValAttrName(), convert(attr)));
+        } else if (attr.getName().getValue() ==
+                   LLVM::LLVMDialect::getByRefAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getByRefAttrName(), convert(attr)));
+        } else if (attr.getName().getValue() ==
+                   LLVM::LLVMDialect::getStructRetAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getStructRetAttrName(), convert(attr)));
+        } else if (attr.getName().getValue() ==
+                   LLVM::LLVMDialect::getInAllocaAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getInAllocaAttrName(), convert(attr)));
+        } else {
+          convertedAttrs.push_back(attr);
+        }
+      }
+      auto mapping = signatureConversion.getInputMapping(i);
+      assert(mapping && "unexpected deletion of function argument");
+      for (size_t j = 0; j < mapping->size; ++j)
+        newArgAttrs[mapping->inputNo + j] =
+            DictionaryAttr::get(rewriter.getContext(), convertedAttrs);
+    }
+    attributes.push_back(
+        rewriter.getNamedAttr(FunctionOpInterface::getArgDictAttrName(),
+                              rewriter.getArrayAttr(newArgAttrs)));
+  }
+  for (const auto &pair : llvm::enumerate(attributes)) {
+    if (pair.value().getName() == kLLVMLinkageAttrName) {
+      attributes.erase(attributes.begin() + pair.index());
+      break;
+    }
+  }
+
+  return attributes;
+}
+
+/// Returns the LLVM dialect type suitable for constructing the LLVM function
+/// type that has the same results as the given type. If multiple results are to
+/// be returned, packs them into an anonymous LLVM dialect structure type.
+static Type convertAndPackFunctionResultType(FunctionType type,
+                                             TypeConverter &typeConverter) {
+  SmallVector<Type> convertedResultTypes;
+  if (failed(
+          typeConverter.convertTypes(type.getResults(), convertedResultTypes)))
+    return nullptr;
+
+  if (convertedResultTypes.empty())
+    return LLVM::LLVMVoidType::get(type.getContext());
+  if (convertedResultTypes.size() == 1)
+    return convertedResultTypes[0];
+  return LLVM::LLVMStructType::getLiteral(type.getContext(),
+                                          convertedResultTypes);
+}
+
+/// Attempts to convert the function type representing the signature of the
+/// given function to the LLVM dialect equivalent type. On success, returns the
+/// converted type and the signature conversion object that can be used to
+/// update the arguments of the function's entry block.
+static Optional<
+    std::pair<LLVM::LLVMFunctionType, TypeConverter::SignatureConversion>>
+convertFunctionType(func::FuncOp funcOp, TypeConverter &typeConverter) {
+  TypeConverter::SignatureConversion signatureConversion(
+      funcOp.getNumArguments());
+  for (const auto &[index, type] : llvm::enumerate(funcOp.getArgumentTypes())) {
+    Type converted = typeConverter.convertType(type);
+    if (!converted)
+      return llvm::None;
+
+    signatureConversion.addInputs(index, converted);
+  }
+
+  Type resultType =
+      convertAndPackFunctionResultType(funcOp.getFunctionType(), typeConverter);
+  if (!resultType)
+    return llvm::None;
+
+  auto varargsAttr = funcOp->getAttrOfType<BoolAttr>("func.varargs");
+  auto convertedType = LLVM::LLVMFunctionType::get(
+      resultType, signatureConversion.getConvertedTypes(),
+      varargsAttr && varargsAttr.getValue());
+
+  return std::make_pair(convertedType, signatureConversion);
+}
+
+namespace {
+/// Pattern for function declarations and definitions.
+struct FuncOpLowering : public ConvertOpToLLVMPattern<func::FuncOp> {
+public:
+  using ConvertOpToLLVMPattern<func::FuncOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(func::FuncOp funcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto typePair = convertFunctionType(funcOp, *typeConverter);
+    if (!typePair)
+      return rewriter.notifyMatchFailure(funcOp->getLoc(),
+                                         "failed to convert signature");
+
+    auto [convertedType, conversionSignature] = *typePair;
+    SmallVector<NamedAttribute> attributes = convertFuncAttributes(
+        funcOp, *typeConverter, conversionSignature, rewriter);
+
+    LLVM::Linkage linkage = LLVM::Linkage::External;
+    if (funcOp->hasAttr(kLLVMLinkageAttrName)) {
+      auto attr =
+          funcOp->getAttr(kLLVMLinkageAttrName).cast<mlir::LLVM::LinkageAttr>();
+      linkage = attr.getLinkage();
+    }
+    auto newFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
+        funcOp.getLoc(), funcOp.getName(), convertedType, linkage,
+        /*dsoLocal=*/false, /*cconv=*/LLVM::CConv::C, attributes);
+    rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
+                                newFuncOp.end());
+    if (failed(rewriter.convertRegionTypes(&newFuncOp.getBody(), *typeConverter,
+                                           &conversionSignature))) {
+      return rewriter.notifyMatchFailure(
+          funcOp->getLoc(), "failed to apply signature conversion");
+    }
+
+    rewriter.eraseOp(funcOp);
+    return success();
+  }
+};
+
+/// Pattern for function calls, unpacks the results from the struct.
+struct CallOpLowering : public ConvertOpToLLVMPattern<func::CallOp> {
+public:
+  using ConvertOpToLLVMPattern<func::CallOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(func::CallOp callOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    unsigned numResults = callOp.getNumResults();
+    SmallVector<Type, 1> callResultTypes;
+    if (!callOp.getResults().empty()) {
+      callResultTypes.push_back(convertAndPackFunctionResultType(
+          callOp.getCalleeType(), *typeConverter));
+      if (!callResultTypes.back()) {
+        return rewriter.notifyMatchFailure(
+            callOp.getLoc(), "failed to convert callee signature");
+      }
+    }
+
+    auto newCallOp = rewriter.create<LLVM::CallOp>(
+        callOp->getLoc(), callResultTypes, adaptor.getOperands(),
+        callOp->getAttrs());
+
+    if (numResults <= 1) {
+      rewriter.replaceOp(callOp, newCallOp->getResults());
+      return success();
+    }
+
+    SmallVector<Value> results;
+    results.reserve(numResults);
+    for (auto index : llvm::seq<unsigned>(0, numResults)) {
+      results.push_back(rewriter.create<LLVM::ExtractValueOp>(
+          callOp->getLoc(), newCallOp->getResult(0), index));
+    }
+    rewriter.replaceOp(callOp, results);
+    return success();
+  }
+};
+
+/// Pattern for returning from a function, packs the results into a struct.
+struct ReturnOpLowering : public ConvertOpToLLVMPattern<func::ReturnOp> {
+public:
+  using ConvertOpToLLVMPattern<func::ReturnOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(func::ReturnOp returnOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (returnOp->getNumOperands() <= 1) {
+      rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(returnOp,
+                                                  adaptor.getOperands());
+      return success();
+    }
+
+    auto returnedType = LLVM::LLVMStructType::getLiteral(
+        returnOp->getContext(),
+        llvm::to_vector(adaptor.getOperands().getTypes()));
+    Value packed =
+        rewriter.create<LLVM::UndefOp>(returnOp->getLoc(), returnedType);
+    for (const auto &[index, value] : llvm::enumerate(adaptor.getOperands())) {
+      packed = rewriter.create<LLVM::InsertValueOp>(returnOp->getLoc(), packed,
+                                                    value, index);
+    }
+    rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(returnOp, packed);
+    return success();
+  }
+};
+
+/// Appends the patterns lowering operations from the Memref dialect to the LLVM
+/// dialect using the C-style type conversion, i.e. converting memrefs to
+/// pointer to arrays of arrays.
+static void
+populateCStyleMemRefLoweringPatterns(RewritePatternSet &patterns,
+                                     LLVMTypeConverter &typeConverter) {
+  patterns.add<AllocaOpLowering, AllocOpLowering, DeallocOpLowering,
+               GetGlobalOpLowering, GlobalOpLowering, LoadOpLowering,
+               StoreOpLowering>(typeConverter);
+}
+
+/// Appends the patterns lowering operations from the Func dialect to the LLVM
+/// dialect using the C-style type conversion, i.e. converting memrefs to
+/// pointer to arrays of arrays.
+static void
+populateCStyleFuncLoweringPatterns(RewritePatternSet &patterns,
+                                   LLVMTypeConverter &typeConverter) {
+  patterns.add<CallOpLowering, FuncOpLowering, ReturnOpLowering>(typeConverter);
+}
+} // namespace
+
+//===-----------------------------------------------------------------------===/
+
+namespace {
 struct ConvertPolygeistToLLVMPass
     : public ConvertPolygeistToLLVMBase<ConvertPolygeistToLLVMPass> {
   ConvertPolygeistToLLVMPass() = default;
@@ -640,6 +1217,13 @@ struct ConvertPolygeistToLLVMPass
     ModuleOp m = getOperation();
     const auto &dataLayoutAnalysis = getAnalysis<DataLayoutAnalysis>();
 
+    if (useCStyleMemRef && useBarePtrCallConv) {
+      emitError(m.getLoc()) << "C-style memref lowering is not compatible with "
+                               "bare-pointer calling convention";
+      signalPassFailure();
+      return;
+    }
+
     LowerToLLVMOptions options(&getContext(),
                                dataLayoutAnalysis.getAtOrAbove(m));
     options.useBarePtrCallConv = useBarePtrCallConv;
@@ -650,14 +1234,51 @@ struct ConvertPolygeistToLLVMPass
 
     for (int i = 0; i < 2; i++) {
 
+      // Define the type converter. Override the default behavior for memrefs if
+      // requested.
       LLVMTypeConverter converter(&getContext(), options, &dataLayoutAnalysis);
+      if (useCStyleMemRef) {
+        converter.addConversion([&](MemRefType type) -> Optional<Type> {
+          Type converted = converter.convertType(type.getElementType());
+          if (!converted)
+            return Type();
+
+          if (type.getRank() == 0) {
+            return LLVM::LLVMPointerType::get(converted,
+                                              type.getMemorySpaceAsInt());
+          }
+
+          // Only the leading dimension can be dynamic.
+          if (llvm::any_of(type.getShape().drop_front(), ShapedType::isDynamic))
+            return Type();
+
+          // Only identity layout is supported.
+          // TODO: detect the strided layout that is equivalent to identity
+          // given the static part of the shape.
+          if (!type.getLayout().isIdentity())
+            return Type();
+
+          if (type.getRank() > 0) {
+            for (int64_t size : llvm::reverse(type.getShape().drop_front()))
+              converted = LLVM::LLVMArrayType::get(converted, size);
+          }
+          return LLVM::LLVMPointerType::get(converted,
+                                            type.getMemorySpaceAsInt());
+        });
+      }
+
       RewritePatternSet patterns(&getContext());
       populatePolygeistToLLVMConversionPatterns(converter, patterns);
       populateSCFToControlFlowConversionPatterns(patterns);
       populateForBreakToWhilePatterns(patterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, patterns);
-      populateMemRefToLLVMConversionPatterns(converter, patterns);
-      populateFuncToLLVMConversionPatterns(converter, patterns);
+      if (useCStyleMemRef) {
+        populateCStyleMemRefLoweringPatterns(patterns, converter);
+        populateCStyleFuncLoweringPatterns(patterns, converter);
+      } else {
+        populateMemRefToLLVMConversionPatterns(converter, patterns);
+        populateFuncToLLVMConversionPatterns(converter, patterns);
+      }
       populateMathToLLVMConversionPatterns(converter, patterns);
       populateOpenMPToLLVMConversionPatterns(converter, patterns);
       arith::populateArithmeticToLLVMConversionPatterns(converter, patterns);


### PR DESCRIPTION
Introduce an alternative lowering scheme for memref types. A n-D memref is always lowered to a pointer to an (n-1)-D nested LLVM array type, a 0-D and a 1-D memref is lowered to a bare pointer. This applies both at function boundaries and within functions, unlike the MLIR's bare pointer calling convention. This lowering is only possible for memrefs with static shapes except for the outermost dimension, which is consistent with the kinds of nested array structure C allows and therefore suitable for a C frontend. However, it only supports a subset of memref dialect operations that are possible to implement using this data structure. For example, view, subview and transpose cannot be implemented as they result in non-row-major layouts unexpressible with C nested arrays.

This simplifies the lowering and the generated IR for all supported memref operations and removes the need for the ABI duplication at the function boundary: memrefs are lowered to the same LLVM IR as equivalent nested arrays.