### PR TITLE
Enable shared library build.

### DIFF
--- a/lib/polygeist/CMakeLists.txt
+++ b/lib/polygeist/CMakeLists.txt
@@ -11,5 +11,10 @@ MLIRPolygeistOpsIncGen
 LINK_LIBS PUBLIC
 MLIRIR
 MLIRMemRefDialect
+MLIRLLVMDialect
+MLIROpenMPDialect
+MLIRAffineDialect
+MLIRSupport
+MLIRSCFTransforms
 )
 add_subdirectory(Passes)

--- a/lib/polygeist/Ops.cpp
+++ b/lib/polygeist/Ops.cpp
@@ -260,7 +260,6 @@ bool isReadNone(Operation *op) {
   return false;
 }
 
-
 class BarrierHoist final : public OpRewritePattern<BarrierOp> {
 public:
   using OpRewritePattern<BarrierOp>::OpRewritePattern;

--- a/lib/polygeist/Ops.cpp
+++ b/lib/polygeist/Ops.cpp
@@ -199,7 +199,67 @@ void BarrierOp::getEffects(
     return;
 }
 
-bool isReadNone(Operation *op);
+bool isReadOnly(Operation *op) {
+  bool hasRecursiveEffects = op->hasTrait<OpTrait::HasRecursiveSideEffects>();
+  if (hasRecursiveEffects) {
+    for (Region &region : op->getRegions()) {
+      for (auto &block : region) {
+        for (auto &nestedOp : block)
+          if (!isReadOnly(&nestedOp))
+            return false;
+      }
+    }
+    return true;
+  }
+
+  // If the op has memory effects, try to characterize them to see if the op
+  // is trivially dead here.
+  if (auto effectInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    // Check to see if this op either has no effects, or only allocates/reads
+    // memory.
+    SmallVector<MemoryEffects::EffectInstance, 1> effects;
+    effectInterface.getEffects(effects);
+    if (!llvm::all_of(effects, [op](const MemoryEffects::EffectInstance &it) {
+          return isa<MemoryEffects::Read>(it.getEffect());
+        })) {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+bool isReadNone(Operation *op) {
+  bool hasRecursiveEffects = op->hasTrait<OpTrait::HasRecursiveSideEffects>();
+  if (hasRecursiveEffects) {
+    for (Region &region : op->getRegions()) {
+      for (auto &block : region) {
+        for (auto &nestedOp : block)
+          if (!isReadNone(&nestedOp))
+            return false;
+      }
+    }
+    return true;
+  }
+
+  // If the op has memory effects, try to characterize them to see if the op
+  // is trivially dead here.
+  if (auto effectInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    // Check to see if this op either has no effects, or only allocates/reads
+    // memory.
+    SmallVector<MemoryEffects::EffectInstance, 1> effects;
+    effectInterface.getEffects(effects);
+    if (llvm::any_of(effects, [op](const MemoryEffects::EffectInstance &it) {
+          return isa<MemoryEffects::Read>(it.getEffect()) ||
+                 isa<MemoryEffects::Write>(it.getEffect());
+        })) {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
 
 class BarrierHoist final : public OpRewritePattern<BarrierOp> {
 public:

--- a/lib/polygeist/Passes/CMakeLists.txt
+++ b/lib/polygeist/Passes/CMakeLists.txt
@@ -41,4 +41,9 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRSideEffectInterfaces
   MLIRSCFToControlFlow
   MLIRTransformUtils
+  MLIRControlFlowToLLVM
+  MLIRMemRefToLLVM
+  MLIRFuncToLLVM
+  MLIRArithToLLVM
+  MLIROpenMPToLLVM
   )


### PR DESCRIPTION
* This patch can enable Polygeist as shared library. aka, when cmake config append with `-DBUILD_SHARED_LIBS=ON`.

* Change is simple, just add missing libray and move two functions to Ops.cpp from OpenMPOpt.cpp.

Signed-off-by: fanfuqiang <fuqiang.fan@mthreads.com>