### PR TITLE
Use SmallString<0> instead of std::string in ArgumentList

### DIFF
--- a/tools/cgeist/ArgumentList.h
+++ b/tools/cgeist/ArgumentList.h
@@ -10,7 +10,7 @@
 #define MLIR_TOOLS_CGEIST_ARGUMENTLIST_H
 
 #include <llvm/ADT/ArrayRef.h>
-#include <llvm/Support/raw_ostream.h>
+#include <llvm/ADT/SmallString.h>
 
 namespace mlirclang {
 /// Class to pass options to a compilation tool.
@@ -24,13 +24,9 @@ public:
   /// Add argument and ensure it will be valid before this passer's destruction.
   ///
   /// The element stored will be owned by this.
-  template <typename... ArgTy> void emplace_back(ArgTy &&...Args) {
+  void emplace_back(std::initializer_list<llvm::StringRef> Refs) {
     // Store as a string
-    std::string Buffer;
-    llvm::raw_string_ostream Stream(Buffer);
-    (Stream << ... << Args);
-    Storage.push_back(Stream.str());
-    push_back(Storage.back());
+    push_back(Storage.emplace_back(Refs).c_str());
   }
 
   /// Return the underling argument list.
@@ -41,7 +37,7 @@ public:
 
 private:
   /// Helper storage.
-  llvm::SmallVector<std::string> Storage;
+  llvm::SmallVector<llvm::SmallString<0>> Storage;
   /// List of arguments
   llvm::SmallVector<const char *> Args;
 };

--- a/tools/cgeist/Lib/clang-mlir.cc
+++ b/tools/cgeist/Lib/clang-mlir.cc
@@ -5523,10 +5523,10 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
     Argv.push_back(TargetTripleOpt);
   }
   if (McpuOpt != "") {
-    Argv.emplace_back("-mcpu=", McpuOpt);
+    Argv.emplace_back({"-mcpu=", McpuOpt});
   }
   if (Standard != "") {
-    Argv.emplace_back("-std=", Standard);
+    Argv.emplace_back({"-std=", Standard});
   }
   if (ResourceDir != "") {
     Argv.push_back("-resource-dir");
@@ -5546,20 +5546,20 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
     Argv.push_back("-nocudalib");
   }
   if (CUDAGPUArch != "") {
-    Argv.emplace_back("--cuda-gpu-arch=", CUDAGPUArch);
+    Argv.emplace_back({"--cuda-gpu-arch=", CUDAGPUArch});
   }
   if (CUDAPath != "") {
-    Argv.emplace_back("--cuda-path=", CUDAPath);
+    Argv.emplace_back({"--cuda-path=", CUDAPath});
   }
   if (MArch != "") {
-    Argv.emplace_back("-march=", MArch);
+    Argv.emplace_back({"-march=", MArch});
   }
   for (const auto &dir : includeDirs) {
     Argv.push_back("-I");
     Argv.push_back(dir);
   }
   for (const auto &define : defines) {
-    Argv.emplace_back("-D", define);
+    Argv.emplace_back({"-D", define});
   }
   for (const auto &Include : Includes) {
     Argv.push_back("-include");

--- a/tools/cgeist/Test/Verification/defines.c
+++ b/tools/cgeist/Test/Verification/defines.c
@@ -1,0 +1,15 @@
+// RUN: cgeist -DOUTPUT -DTEST -c %s -S | FileCheck %s
+
+int main(int argc, char **argv)
+{
+#ifdef OUTPUT
+        return 1;
+#else
+        return 2;
+#endif
+}
+
+// CHECK:   func.func @main(%arg0: i32, %arg1: memref<?xmemref<?xi8>>) -> i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     return %c1_i32 : i32
+// CHECK-NEXT:   }

--- a/tools/cgeist/driver.cc
+++ b/tools/cgeist/driver.cc
@@ -280,10 +280,10 @@ int emitBinary(char *Argv0, const char *filename,
     Argv.push_back("-v");
   }
   if (CUDAGPUArch != "") {
-    Argv.emplace_back("--cuda-gpu-arch=", CUDAGPUArch);
+    Argv.emplace_back({"--cuda-gpu-arch=", CUDAGPUArch});
   }
   if (CUDAPath != "") {
-    Argv.emplace_back("--cuda-path=", CUDAPath);
+    Argv.emplace_back({"--cuda-path=", CUDAPath});
   }
   if (Opt0) {
     Argv.push_back("-O0");


### PR DESCRIPTION
Use llvm::SmallString<0> instead of std::string in ArgumentList to avoid bug caused by small string optimizations and invalidation of iterators to the Storage vector.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>