### PR TITLE
Warn but enable unregistered dialects for pragma

### DIFF
--- a/tools/cgeist/Lib/utils.cc
+++ b/tools/cgeist/Lib/utils.cc
@@ -45,8 +45,10 @@ Operation *mlirclang::replaceFuncByOperation(
     func::FuncOp f, StringRef opName, OpBuilder &b,
     SmallVectorImpl<mlir::Value> &input, SmallVectorImpl<mlir::Value> &output) {
   MLIRContext *ctx = f->getContext();
-  assert(ctx->isOperationRegistered(opName) &&
-         "Provided lower_to opName should be registered.");
+  if (!ctx->isOperationRegistered(opName)) {
+    ctx->allowUnregisteredDialects();
+    llvm::errs() << " warning unregistered dialect op: " << opName << "\n";
+  }
 
   if (opName.startswith("memref"))
     return buildLinalgOp(opName, b, input, output);


### PR DESCRIPTION
@pengmai

```c
#pragma lower_to(__enzyme_autodiff, "enzyme.autodiff")
extern double __enzyme_autodiff(void*, double);

double square(double x) {
    return x * x;
}

double dsquare(double x) {
    // This returns the derivative of square or 2 * x
    return __enzyme_autodiff((void*)square, x);
}
```

```mlir
module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu", "polygeist.target-cpu" = "x86-64", "polygeist.target-features" = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87", "polygeist.tune-cpu" = "generic"} {
  func.func @square(%arg0: f64) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
    %0 = arith.mulf %arg0, %arg0 : f64
    return %0 : f64
  }
  func.func @dsquare(%arg0: f64) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
    %0 = polygeist.get_func @square : <func<f64 (f64)>>
    %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<func<f64 (f64)>>) -> memref<?xi8>
    %2 = "enzyme.autodiff"(%1, %arg0) : (memref<?xi8>, f64) -> f64
    return %2 : f64
  }
}
```