### PR TITLE
Append another case for converting floating point to complex

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,3 @@ ninja check-polygeist-opt && ninja check-cgeist
 
 `ninja check-polygeist-opt` runs the tests in `Polygeist/test/polygeist-opt`
 `ninja check-cgeist` runs the tests in `Polygeist/tools/cgeist/Test`
-### 1. It's just a test

--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ ninja check-polygeist-opt && ninja check-cgeist
 
 `ninja check-polygeist-opt` runs the tests in `Polygeist/test/polygeist-opt`
 `ninja check-cgeist` runs the tests in `Polygeist/tools/cgeist/Test`
+### 1. It's just a test

--- a/tools/cgeist/Lib/clang-mlir.cc
+++ b/tools/cgeist/Lib/clang-mlir.cc
@@ -4432,7 +4432,25 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     }
     return ValueCategory(res, /*isReference*/ false);
   }
-
+    //===- test code snippet--------------------------------------------*- C-*-===//
+    //Run ./cgeist -S -function="complex_test" complex.c
+    // #include<complex.h>
+    // _Complex double complex_test(void){
+    // _Complex double z=1.0;
+    // return z;
+    //}
+    //===----------------------------------------------------------------------===//
+  case clang::CastKind::CK_FloatingRealToComplex:{
+    auto sub = Visit(E->getSubExpr());
+    auto complex = sub.val;
+    auto real = sub.getValue(loc,builder);
+    mlir::FloatType fty;
+    fty = complex.getType().dyn_cast<mlir::FloatType>();
+    auto zero = builder.create<ConstantFloatOp>(
+        loc, APFloat(fty.getFloatSemantics(),"0"),fty
+        );
+    return createComplexFloat(loc,real,zero,E->getType());
+  }
   default:
     if (EmittingFunctionDecl)
       EmittingFunctionDecl->dump();


### PR DESCRIPTION
Hi~, I'm currently facing a challenge in my code where I need to convert a real floating-point number into a complex type, with the imaginary part explicitly set to zero. However, I encounter an  Assertion `mt.getShape().size() == smt.getSha().size()' failed which is indicated in the file 'ValueCategory.cc' at line 168. I would greatly appreciate any guidance on how to resolve this issue.