### PR TITLE
Fail when clang FE returned an error

### DIFF
--- a/tools/cgeist/Lib/clang-mlir.cc
+++ b/tools/cgeist/Lib/clang-mlir.cc
@@ -6136,6 +6136,10 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
         Act.EndSourceFile();
       }
     }
+
+    if (Clang->getDiagnostics().hasErrorOccurred()) {
+      return false;
+    }
   }
   return true;
 }

--- a/tools/cgeist/Test/Verification/freecst.c
+++ b/tools/cgeist/Test/Verification/freecst.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s %stdinclude --function=* -S | FileCheck %s
 
 #include <stdlib.h>
     struct band {

--- a/tools/cgeist/Test/Verification/invalid/basic.cpp
+++ b/tools/cgeist/Test/Verification/invalid/basic.cpp
@@ -1,3 +1,4 @@
-// RUN: not cgeist %s --function=* -S
+// RUN: cgeist %s --function=* -S
+// XFAIL: *
 
 int main() {

--- a/tools/cgeist/Test/Verification/invalid/basic.cpp
+++ b/tools/cgeist/Test/Verification/invalid/basic.cpp
@@ -1,0 +1,3 @@
+// RUN: not cgeist %s --function=* -S
+
+int main() {

--- a/tools/cgeist/Test/Verification/invalid/invalid_include.cpp
+++ b/tools/cgeist/Test/Verification/invalid/invalid_include.cpp
@@ -1,0 +1,3 @@
+// RUN: not cgeist %s --function=* -S
+
+#include "non-existing-header.h"

--- a/tools/cgeist/Test/Verification/invalid/invalid_include.cpp
+++ b/tools/cgeist/Test/Verification/invalid/invalid_include.cpp
@@ -1,3 +1,4 @@
-// RUN: not cgeist %s --function=* -S
+// RUN: cgeist %s --function=* -S
+// XFAIL: *
 
 #include "non-existing-header.h"

--- a/tools/cgeist/Test/Verification/memref-fullrank.c
+++ b/tools/cgeist/Test/Verification/memref-fullrank.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -S --function=main -memref-fullrank -O0 | FileCheck %s
+// RUN: cgeist %s -S %stdinclude --function=main -memref-fullrank -O0 | FileCheck %s
 
 #include <stdio.h>
 

--- a/tools/cgeist/Test/Verification/ompParallelNumThreads.c
+++ b/tools/cgeist/Test/Verification/ompParallelNumThreads.c
@@ -1,5 +1,6 @@
 // RUN: cgeist %s --function=* -fopenmp -S | FileCheck %s
-#include <omp.h>
+
+int omp_get_thread_num();
 
 void test_parallel_num_threads(double* x, int sinc) {
     // CHECK: %[[c32:.+]] = arith.constant 32 : i32

--- a/tools/cgeist/Test/Verification/raiseToAffineUnsignedCmp.c
+++ b/tools/cgeist/Test/Verification/raiseToAffineUnsignedCmp.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=matmul --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist %s %stdinclude --function=matmul --raise-scf-to-affine -S | FileCheck %s
 
 void matmul(float A[100][200], float B[200][300], float C[100][300]) {
   int i, j, k;
@@ -21,4 +21,4 @@ void matmul(float A[100][200], float B[200][300], float C[100][300]) {
       }
     }
   }
-
+}

--- a/tools/cgeist/Test/Verification/triple.cu
+++ b/tools/cgeist/Test/Verification/triple.cu
@@ -1,5 +1,5 @@
-// RUN: cgeist --target aarch64-unknown-linux-gnu %s %stdinclude -S -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cgeist --target aarch64-unknown-linux-gnu %s %stdinclude -emit-llvm -S -o - | FileCheck %s -check-prefix=LLVM
+// RUN: cgeist --target aarch64-unknown-linux-gnu %s -nocudalib -nocudainc %stdinclude -S -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cgeist --target aarch64-unknown-linux-gnu %s -nocudalib -nocudainc %stdinclude -emit-llvm -S -o - | FileCheck %s -check-prefix=LLVM
 
 // MLIR:  llvm.target_triple = "aarch64-unknown-linux-gnu"
 // LLVM:  target triple = "aarch64-unknown-linux-gnu"

--- a/tools/cgeist/driver.cc
+++ b/tools/cgeist/driver.cc
@@ -571,8 +571,11 @@ int main(int argc, char **argv) {
   llvm::DataLayout DL("");
   llvm::Triple gpuTriple;
   llvm::DataLayout gpuDL("");
-  parseMLIR(argv[0], files, cfunction, includeDirs, defines, module, triple, DL,
-            gpuTriple, gpuDL);
+  if (!parseMLIR(argv[0], files, cfunction, includeDirs, defines, module,
+                 triple, DL, gpuTriple, gpuDL)) {
+    llvm::errs() << "parseMLIR failed\n";
+    return 1;
+  }
 
   auto convertGepInBounds = [](llvm::Module &llvmModule) {
     for (auto &F : llvmModule) {

--- a/tools/cgeist/driver.cc
+++ b/tools/cgeist/driver.cc
@@ -573,7 +573,6 @@ int main(int argc, char **argv) {
   llvm::DataLayout gpuDL("");
   if (!parseMLIR(argv[0], files, cfunction, includeDirs, defines, module,
                  triple, DL, gpuTriple, gpuDL)) {
-    llvm::errs() << "parseMLIR failed\n";
     return 1;
   }
 


### PR DESCRIPTION
- Add check if clang diagnostics engine reported any errors
- Fix tests that started to fail after clang FE diagnostics checks enabling
- Add basic tests for handling invalid C++ code by cgeist