### PR TITLE
Link c++fs only in case it is needed

### DIFF
--- a/lib/polygeist/Passes/CMakeLists.txt
+++ b/lib/polygeist/Passes/CMakeLists.txt
@@ -60,10 +60,17 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIROpenMPToLLVM
   )
 
-target_link_libraries(MLIRPolygeistTransforms
-  PRIVATE
-  stdc++fs
-  )
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+    target_link_libraries(MLIRPolygeistTransforms PUBLIC stdc++fs)
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
+    target_link_libraries(MLIRPolygeistTransforms PUBLIC c++experimental)
+  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+    target_link_libraries(MLIRPolygeistTransforms PUBLIC c++fs)
+  endif()
+endif()
 
 target_compile_definitions(obj.MLIRPolygeistTransforms
   PRIVATE


### PR DESCRIPTION
On newer versions of gcc and clang compilers, c++fs library has been moved to the standard library and the library itself was removed.

According to official documentation:
- LLVM 9.0+ has built-in support for filesystem library: https://releases.llvm.org/10.0.0/projects/libcxx/docs/UsingLibcxx.html#using-filesystem
- GCC starting with version 9 also does not require this linkage: https://gcc.gnu.org/gcc-9/changes.html