### PR TITLE
Migrate uses of `.dyn_cast` to `llvm::dyn_cast`

### DIFF
--- a/lib/polygeist/Passes/AffineCFG.cpp
+++ b/lib/polygeist/Passes/AffineCFG.cpp
@@ -144,7 +144,7 @@ static bool legalCondition(Value en, bool dim = false) {
   //	if (!outer || legalCondition(IC.getOperand(), false)) return true;
   //}
   if (!dim)
-    if (auto BA = en.dyn_cast<BlockArgument>()) {
+    if (auto BA = llvm::dyn_cast<BlockArgument>(en)) {
       if (isa<affine::AffineForOp, affine::AffineParallelOp>(
               BA.getOwner()->getParentOp()))
         return true;
@@ -730,7 +730,7 @@ static void setLocationAfter(PatternRewriter &b, mlir::Value val) {
     it++;
     b.setInsertionPoint(val.getDefiningOp()->getBlock(), it);
   }
-  if (auto bop = val.dyn_cast<mlir::BlockArgument>())
+  if (auto bop = llvm::dyn_cast<mlir::BlockArgument>(val))
     b.setInsertionPoint(bop.getOwner(), bop.getOwner()->begin());
 }
 
@@ -745,7 +745,7 @@ struct IndexCastMovement : public OpRewritePattern<IndexCastOp> {
     }
 
     mlir::Value val = op.getOperand();
-    if (auto bop = val.dyn_cast<mlir::BlockArgument>()) {
+    if (auto bop = llvm::dyn_cast<mlir::BlockArgument>(val)) {
       if (op.getOperation()->getBlock() != bop.getOwner()) {
         op.getOperation()->moveBefore(bop.getOwner(), bop.getOwner()->begin());
         return success();
@@ -1010,7 +1010,7 @@ bool isValidIndex(Value val) {
   if (val.getDefiningOp<ConstantIntOp>())
     return true;
 
-  if (auto ba = val.dyn_cast<BlockArgument>()) {
+  if (auto ba = llvm::dyn_cast<BlockArgument>(val)) {
     auto *owner = ba.getOwner();
     assert(owner);
 

--- a/lib/polygeist/Passes/CanonicalizeFor.cpp
+++ b/lib/polygeist/Passes/CanonicalizeFor.cpp
@@ -110,7 +110,7 @@ struct ForBreakAddUpgrade : public OpRewritePattern<scf::ForOp> {
 
     auto condition = outerIfOp.getCondition();
     //  and that the outermost if's condition is an iter arg of the for
-    auto condArg = condition.dyn_cast<BlockArgument>();
+    auto condArg = llvm::dyn_cast<BlockArgument>(condition);
     if (!condArg)
       return failure();
     if (condArg.getOwner()->getParentOp() != forOp)
@@ -121,7 +121,7 @@ struct ForBreakAddUpgrade : public OpRewritePattern<scf::ForOp> {
     // and is false unless coming from inside the if
     auto forYieldOp = cast<scf::YieldOp>(block.getTerminator());
     auto opres =
-        forYieldOp.getOperand(condArg.getArgNumber() - 1).dyn_cast<OpResult>();
+        llvm::dyn_cast<OpResult>(forYieldOp.getOperand(condArg.getArgNumber() - 1));
     if (!opres)
       return failure();
     if (opres.getOwner() != outerIfOp)
@@ -143,7 +143,7 @@ struct ForBreakAddUpgrade : public OpRewritePattern<scf::ForOp> {
       if (opres.getResultNumber() == regionArg.getArgNumber() - 1)
         continue;
 
-      auto opres2 = forYieldOperand.dyn_cast<OpResult>();
+      auto opres2 = llvm::dyn_cast<OpResult>(forYieldOperand);
       if (!opres2)
         continue;
       if (opres2.getOwner() != outerIfOp)
@@ -627,13 +627,13 @@ yop2.results()[idx]);
 */
 
 bool isTopLevelArgValue(Value value, Region *region) {
-  if (auto arg = value.dyn_cast<BlockArgument>())
+  if (auto arg = llvm::dyn_cast<BlockArgument>(value))
     return arg.getParentRegion() == region;
   return false;
 }
 
 bool isBlockArg(Value value) {
-  if (auto arg = value.dyn_cast<BlockArgument>())
+  if (auto arg = llvm::dyn_cast<BlockArgument>(value))
     return true;
   return false;
 }
@@ -642,7 +642,7 @@ bool dominateWhile(Value value, WhileOp loop) {
   if (Operation *op = value.getDefiningOp()) {
     DominanceInfo dom(loop);
     return dom.properlyDominates(op, loop);
-  } else if (auto arg = value.dyn_cast<BlockArgument>()) {
+  } else if (auto arg = llvm::dyn_cast<BlockArgument>(value)) {
     return arg.getOwner()->getParentOp()->isProperAncestor(loop);
   } else {
     assert("????");
@@ -682,11 +682,11 @@ struct WhileToForHelper {
     negativeStep = false;
 
     auto condOp = loop.getConditionOp();
-    indVar = cmpIOp.getLhs().dyn_cast<BlockArgument>();
+    indVar = llvm::dyn_cast<BlockArgument>(cmpIOp.getLhs());
     Type extType = nullptr;
     // todo handle ext
     if (auto ext = cmpIOp.getLhs().getDefiningOp<ExtSIOp>()) {
-      indVar = ext.getIn().dyn_cast<BlockArgument>();
+      indVar = llvm::dyn_cast<BlockArgument>(ext.getIn());
       extType = ext.getType();
     }
     // Condition is not the same as an induction variable
@@ -1004,7 +1004,7 @@ struct MoveWhileAndDown : public OpRewritePattern<WhileOp> {
 
       Value extraCmp = andIOp->getOperand(1 - i);
       Value lookThrough = nullptr;
-      if (auto BA = extraCmp.dyn_cast<BlockArgument>()) {
+      if (auto BA = llvm::dyn_cast<BlockArgument>(extraCmp)) {
         lookThrough = oldYield.getOperand(BA.getArgNumber());
       }
       if (!helper.computeLegality(/*sizeCheck*/ false, lookThrough)) {
@@ -1341,7 +1341,7 @@ struct MoveWhileDown2 : public OpRewritePattern<WhileOp> {
           //    yield   i:pair<2>
           // }
           if (!std::get<0>(pair).use_empty()) {
-            if (auto blockArg = elseYielded.dyn_cast<BlockArgument>())
+            if (auto blockArg = llvm::dyn_cast<BlockArgument>(elseYielded))
               if (blockArg.getOwner() == &op.getBefore().front()) {
                 if (afterYield.getResults()[blockArg.getArgNumber()] ==
                         std::get<2>(pair) &&
@@ -1580,7 +1580,7 @@ struct WhileCmpOffset : public OpRewritePattern<WhileOp> {
         if (addI.getOperand(1).getDefiningOp() &&
             !op.getBefore().isAncestor(
                 addI.getOperand(1).getDefiningOp()->getParentRegion()))
-          if (auto blockArg = addI.getOperand(0).dyn_cast<BlockArgument>()) {
+          if (auto blockArg = llvm::dyn_cast<BlockArgument>(addI.getOperand(0))) {
             if (blockArg.getOwner() == &op.getBefore().front()) {
               auto rng = llvm::make_early_inc_range(blockArg.getUses());
 
@@ -1859,7 +1859,7 @@ struct WhileLICM : public OpRewritePattern<WhileOp> {
     auto isDefinedOutsideOfBody = [&](Value value) {
       auto *definingOp = value.getDefiningOp();
       if (!definingOp) {
-        if (auto ba = value.dyn_cast<BlockArgument>())
+        if (auto ba = llvm::dyn_cast<BlockArgument>(value))
           definingOp = ba.getOwner()->getParentOp();
         assert(definingOp);
       }
@@ -2125,7 +2125,7 @@ struct WhileShiftToInduction : public OpRewritePattern<WhileOp> {
     if (!matchPattern(cmpIOp.getRhs(), m_Zero()))
       return failure();
 
-    auto indVar = cmpIOp.getLhs().dyn_cast<BlockArgument>();
+    auto indVar = llvm::dyn_cast<BlockArgument>(cmpIOp.getLhs());
     if (!indVar)
       return failure();
 
@@ -2144,7 +2144,7 @@ struct WhileShiftToInduction : public OpRewritePattern<WhileOp> {
     if (!matchPattern(shiftOp.getRhs(), m_One()))
       return failure();
 
-    auto prevIndVar = shiftOp.getLhs().dyn_cast<BlockArgument>();
+    auto prevIndVar = llvm::dyn_cast<BlockArgument>(shiftOp.getLhs());
     if (!prevIndVar)
       return failure();
 

--- a/lib/polygeist/Passes/CollectKernelStatistics.cpp
+++ b/lib/polygeist/Passes/CollectKernelStatistics.cpp
@@ -197,7 +197,7 @@ std::array<StrideTy, 3> estimateStride(mlir::OperandRange indices,
       } else {
         return UNKNOWN;
       }
-    } else if (auto ba = v.dyn_cast<BlockArgument>()) {
+    } else if (auto ba = llvm::dyn_cast<BlockArgument>(v)) {
       return 0;
       if (isa<gpu::GPUFuncOp>(ba.getOwner()->getParentOp())) {
         return 0;
@@ -339,7 +339,7 @@ static void generateAlternativeKernelDescs(mlir::ModuleOp m) {
               isa<arith::SubFOp>(&op) || isa<arith::AddFOp>(&op) ||
               isa<arith::RemFOp>(&op) || false) {
             int width =
-                op.getOperand(0).getType().dyn_cast<FloatType>().getWidth();
+                llvm::dyn_cast<FloatType>(op.getOperand(0).getType()).getWidth();
             addTo(floatOps, width, blockTrips);
           } else if (isa<arith::MulIOp>(&op) || isa<arith::DivUIOp>(&op) ||
                      isa<arith::DivSIOp>(&op) || isa<arith::SubIOp>(&op) ||

--- a/lib/polygeist/Passes/ConvertParallelToGPU.cpp
+++ b/lib/polygeist/Passes/ConvertParallelToGPU.cpp
@@ -222,7 +222,7 @@ struct AddLaunchBounds : public OpRewritePattern<gpu::LaunchFuncOp> {
       succeeded = true;
     } else {
       assert(blockSize ==
-             gpuFuncOp->getAttr(attrName).dyn_cast<IntegerAttr>().getInt());
+             llvm::dyn_cast<IntegerAttr>(gpuFuncOp->getAttr(attrName)).getInt());
       succeeded = false;
     }
     attrName = "rocdl.max_flat_work_group_size";
@@ -233,7 +233,7 @@ struct AddLaunchBounds : public OpRewritePattern<gpu::LaunchFuncOp> {
       return success();
     } else {
       assert(blockSize ==
-             gpuFuncOp->getAttr(attrName).dyn_cast<IntegerAttr>().getInt());
+             llvm::dyn_cast<IntegerAttr>(gpuFuncOp->getAttr(attrName)).getInt());
       assert(!succeeded);
       return failure();
     }
@@ -525,7 +525,7 @@ struct SplitParallelOp : public OpRewritePattern<polygeist::GPUWrapperOp> {
     llvm::SmallVector<BlockArgument, 3> syncIVs;
     pop->walk([&](polygeist::BarrierOp barrier) {
       for (auto o : barrier.getOperands())
-        if (auto ba = o.dyn_cast<BlockArgument>())
+        if (auto ba = llvm::dyn_cast<BlockArgument>(o))
           if (std::find(syncIVs.begin(), syncIVs.end(), ba) == syncIVs.end())
             syncIVs.push_back(ba);
     });
@@ -1330,7 +1330,7 @@ struct RemovePolygeistNoopOp : public OpRewritePattern<polygeist::NoopOp> {
       scf::ParallelOp pop = nullptr;
       SmallVector<int, 3> threadIndices;
       for (auto operand : noop.getOperands()) {
-        if (auto blockArg = operand.dyn_cast<BlockArgument>()) {
+        if (auto blockArg = llvm::dyn_cast<BlockArgument>(operand)) {
           if (auto _pop = dyn_cast<scf::ParallelOp>(
                   blockArg.getOwner()->getParentOp())) {
             if (!pop)

--- a/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -985,9 +985,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = allocaOp.getLoc();
     MemRefType originalType = allocaOp.getType();
-    auto convertedType = getTypeConverter()
-                             ->convertType(originalType)
-                             .dyn_cast_or_null<LLVM::LLVMPointerType>();
+    auto convertedType =
+      llvm::dyn_cast_or_null<LLVM::LLVMPointerType>(
+        getTypeConverter()->convertType(originalType));
     auto elTy = convertMemrefElementTypeForLLVMPointer(
         originalType, *this->getTypeConverter());
     if (!convertedType || !elTy)
@@ -1015,9 +1015,10 @@ public:
     auto module = allocOp->getParentOfType<ModuleOp>();
     Location loc = allocOp.getLoc();
     MemRefType originalType = allocOp.getType();
-    auto convertedType = getTypeConverter()
-                             ->convertType(originalType)
-                             .dyn_cast_or_null<LLVM::LLVMPointerType>();
+    auto convertedType =
+      llvm::dyn_cast_or_null<LLVM::LLVMPointerType>(
+        getTypeConverter()->convertType(originalType));
+
     if (!convertedType)
       return rewriter.notifyMatchFailure(loc, "unsupported memref type");
     if (adaptor.getAlignment() && adaptor.getAlignment().value() != 0)
@@ -1197,9 +1198,9 @@ protected:
     Location loc = op.getLoc();
     MemRefType originalType = op.getMemRefType();
     auto convertedType =
+      llvm::dyn_cast_or_null<LLVM::LLVMPointerType>(
         this->getTypeConverter()
-            ->convertType(originalType)
-            .template dyn_cast_or_null<LLVM::LLVMPointerType>();
+            ->convertType(originalType));
     if (!convertedType) {
       (void)rewriter.notifyMatchFailure(loc, "unsupported memref type");
       return nullptr;

--- a/lib/polygeist/Passes/ForBreakToWhile.cpp
+++ b/lib/polygeist/Passes/ForBreakToWhile.cpp
@@ -39,7 +39,7 @@ struct ForBreakLoweringPattern : public OpRewritePattern<ForOp> {
       return failure();
 
     // Its condition comes directly from iterargs.
-    auto condition = conditional.getCondition().dyn_cast<BlockArgument>();
+    auto condition = llvm::dyn_cast<BlockArgument>(conditional.getCondition());
     if (!condition || condition.getOwner()->getParentOp() != forOp)
       return failure();
     unsigned iterArgPos = condition.getArgNumber() - 1;
@@ -47,7 +47,7 @@ struct ForBreakLoweringPattern : public OpRewritePattern<ForOp> {
     // The condition is initially <value> and remains false once changed to
     // false. Moveover, values don't change after the condition is set to false.
     auto yield = cast<scf::YieldOp>(body->back());
-    auto yieldedCondition = yield.getOperand(iterArgPos).dyn_cast<OpResult>();
+    auto yieldedCondition = llvm::dyn_cast<OpResult>(yield.getOperand(iterArgPos));
     if (yieldedCondition.getOwner() != conditional)
       return failure();
 
@@ -61,7 +61,7 @@ struct ForBreakLoweringPattern : public OpRewritePattern<ForOp> {
     Block *forEnd = &forOp.getRegion().back();
     auto forYield = cast<scf::YieldOp>(forEnd->getTerminator());
     for (auto op : llvm::enumerate(forYield->getOperands())) {
-      auto opp = op.value().dyn_cast<OpResult>();
+      auto opp = llvm::dyn_cast<OpResult>(op.value());
       if (!opp) {
         return failure();
       }
@@ -69,7 +69,7 @@ struct ForBreakLoweringPattern : public OpRewritePattern<ForOp> {
         return failure();
 
       auto BA =
-          elseYield.getOperand(opp.getResultNumber()).dyn_cast<BlockArgument>();
+          llvm::dyn_cast<BlockArgument>(elseYield.getOperand(opp.getResultNumber()));
       if (!BA) {
         if (iterArgPos == op.index())
           if (matchPattern(elseYield.getOperand(opp.getResultNumber()),
@@ -88,7 +88,7 @@ struct ForBreakLoweringPattern : public OpRewritePattern<ForOp> {
 
     SmallVector<Value> continueArgs;
     for (auto op : forYield->getOperands()) {
-      if (auto opp = op.dyn_cast<OpResult>()) {
+      if (auto opp = llvm::dyn_cast<OpResult>(op)) {
         if (opp.getOwner() == conditional) {
           continueArgs.push_back(
               conditional.thenYield()->getOperand(opp.getResultNumber()));

--- a/lib/polygeist/Passes/ParallelLICM.cpp
+++ b/lib/polygeist/Passes/ParallelLICM.cpp
@@ -34,7 +34,7 @@ static bool canBeParallelHoisted(Operation *op, Operation *scope,
   // Helper to check whether an operation is loop invariant wrt. SSA properties.
   LLVM_DEBUG(llvm::dbgs() << "Checking for parallel hoist: " << *op << "\n");
   auto definedOutside = [&](Value value) {
-    if (auto BA = value.dyn_cast<BlockArgument>())
+    if (auto BA = llvm::dyn_cast<BlockArgument>(value))
       if (willBeMoved.count(BA.getOwner()->getParentOp()))
         return true;
     auto *definingOp = value.getDefiningOp();
@@ -245,7 +245,7 @@ bool below(Value bval, int64_t val) {
   if (val == -1)
     return false;
 
-  if (auto baval = bval.dyn_cast<BlockArgument>()) {
+  if (auto baval = llvm::dyn_cast<BlockArgument>(bval)) {
     if (affine::AffineForOp afFor =
             dyn_cast<affine::AffineForOp>(baval.getOwner()->getParentOp())) {
       for (auto ub : afFor.getUpperBoundMap().getResults()) {

--- a/lib/polygeist/Passes/ParallelLoopDistribute.cpp
+++ b/lib/polygeist/Passes/ParallelLoopDistribute.cpp
@@ -286,7 +286,7 @@ static void minCutCache(polygeist::BarrierOp barrier,
       for (auto N : pair.second) {
         if (parent.find(N) == parent.end()) {
           assert(pair.first.type == Node::OP && N.type == Node::VAL);
-          assert(pair.first.O == N.V.dyn_cast<OpResult>().getOwner());
+          assert(pair.first.O == llvm::dyn_cast<OpResult>(N.V).getOwner());
           Cache.insert(N.V);
         }
       }
@@ -396,7 +396,7 @@ static bool hasNestedBarrier(Operation *op, SmallVector<BlockArgument> &vals) {
     // the `parallel` op is not an ancestor of `op` or `op` itself), the
     // barrier is considered nested in that `parallel` op and _not_ in `op`.
     for (auto arg : barrier->getOperands()) {
-      if (auto ba = arg.dyn_cast<BlockArgument>()) {
+      if (auto ba = llvm::dyn_cast<BlockArgument>(arg)) {
         if (auto parallel =
                 dyn_cast<scf::ParallelOp>(ba.getOwner()->getParentOp())) {
           if (parallel->isAncestor(op))
@@ -2326,7 +2326,7 @@ struct Reg2MemIf : public OpRewritePattern<T> {
           while (!todo.empty()) {
             auto cur = todo.pop_back_val();
 
-            if (auto BA = cur.dyn_cast<BlockArgument>())
+            if (auto BA = llvm::dyn_cast<BlockArgument>(cur))
               if (BA.getOwner() == op->getBlock())
                 continue;
 
@@ -2426,7 +2426,7 @@ struct Reg2MemIf : public OpRewritePattern<T> {
           while (!todo.empty()) {
             auto cur = todo.pop_back_val();
 
-            if (auto BA = cur.dyn_cast<BlockArgument>())
+            if (auto BA = llvm::dyn_cast<BlockArgument>(cur))
               if (BA.getOwner() == op->getBlock())
                 continue;
             if (cur.getParentRegion()->isProperAncestor(
@@ -2485,7 +2485,7 @@ struct Reg2MemIf : public OpRewritePattern<T> {
           while (!todo.empty()) {
             auto cur = todo.pop_back_val();
 
-            if (auto BA = cur.dyn_cast<BlockArgument>())
+            if (auto BA = llvm::dyn_cast<BlockArgument>(cur))
               if (BA.getOwner() == op->getBlock())
                 continue;
 

--- a/lib/polygeist/Passes/ParallelLoopUnroll.cpp
+++ b/lib/polygeist/Passes/ParallelLoopUnroll.cpp
@@ -93,7 +93,7 @@ static LogicalResult generateUnrolledInterleavedLoop(
         .wasInterrupted();
   };
   auto threadIndependent = [&](Value v) -> bool {
-    if (auto BA = v.dyn_cast<BlockArgument>()) {
+    if (auto BA = llvm::dyn_cast<BlockArgument>(v)) {
       if (BA == srcIV)
         return false;
       return BA.getOwner()->getParentOp()->isAncestor(srcBlock->getParentOp());

--- a/lib/polygeist/Passes/ParallelLower.cpp
+++ b/lib/polygeist/Passes/ParallelLower.cpp
@@ -258,7 +258,7 @@ void ParallelLower::runOnOperation() {
 
     auto callable = caller.getCallableForCallee();
     CallableOpInterface callableOp;
-    if (SymbolRefAttr symRef = callable.dyn_cast<SymbolRefAttr>()) {
+    if (SymbolRefAttr symRef = llvm::dyn_cast<SymbolRefAttr>(callable)) {
       if (!symRef.isa<FlatSymbolRefAttr>())
         return;
       auto *symbolOp =
@@ -312,7 +312,7 @@ void ParallelLower::runOnOperation() {
 
     auto callable = caller.getCallableForCallee();
     CallableOpInterface callableOp;
-    if (SymbolRefAttr symRef = callable.dyn_cast<SymbolRefAttr>()) {
+    if (SymbolRefAttr symRef = llvm::dyn_cast<SymbolRefAttr>(callable)) {
       if (!symRef.isa<FlatSymbolRefAttr>())
         return;
       auto *symbolOp =
@@ -730,7 +730,7 @@ void FixGPUFunc::runOnOperation() {
 
     auto callable = caller.getCallableForCallee();
     CallableOpInterface callableOp;
-    if (SymbolRefAttr symRef = callable.dyn_cast<SymbolRefAttr>()) {
+    if (SymbolRefAttr symRef = llvm::dyn_cast<SymbolRefAttr>(callable)) {
       auto *symbolOp =
           symbolTable.lookupNearestSymbolFrom(getOperation(), symRef);
       callableOp = dyn_cast_or_null<CallableOpInterface>(symbolOp);
@@ -771,7 +771,7 @@ void FixGPUFunc::runOnOperation() {
       return;
     Operation *funcOp;
     if (SymbolRefAttr symRef =
-            callOp.getCallableForCallee().dyn_cast<SymbolRefAttr>()) {
+            llvm::dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee())) {
       auto *symbolOp =
           symbolTable.lookupNearestSymbolFrom(getOperation(), symRef);
       funcOp = dyn_cast_or_null<CallableOpInterface>(symbolOp);
@@ -806,7 +806,7 @@ void ConvertCudaRTtoCPU::runOnOperation() {
           OpBuilder bz(call);
           auto falsev = bz.create<ConstantIntOp>(call->getLoc(), false, 1);
           auto dst = call->getOperand(0);
-          if (auto mt = dst.getType().dyn_cast<MemRefType>()) {
+          if (auto mt = llvm::dyn_cast<MemRefType>(dst.getType())) {
             dst = bz.create<polygeist::Memref2PointerOp>(
                 call->getLoc(),
                 LLVM::LLVMPointerType::get(mt.getElementType(),
@@ -814,7 +814,7 @@ void ConvertCudaRTtoCPU::runOnOperation() {
                 dst);
           }
           auto src = call->getOperand(1);
-          if (auto mt = src.getType().dyn_cast<MemRefType>()) {
+          if (auto mt = llvm::dyn_cast<MemRefType>(src.getType())) {
             src = bz.create<polygeist::Memref2PointerOp>(
                 call->getLoc(),
                 LLVM::LLVMPointerType::get(mt.getElementType(),
@@ -831,7 +831,7 @@ void ConvertCudaRTtoCPU::runOnOperation() {
           OpBuilder bz(call);
           auto falsev = bz.create<ConstantIntOp>(call->getLoc(), false, 1);
           auto dst = call->getOperand(0);
-          if (auto mt = dst.getType().dyn_cast<MemRefType>()) {
+          if (auto mt = llvm::dyn_cast<MemRefType>(dst.getType())) {
             dst = bz.create<polygeist::Memref2PointerOp>(
                 call->getLoc(),
                 LLVM::LLVMPointerType::get(mt.getElementType(),
@@ -839,7 +839,7 @@ void ConvertCudaRTtoCPU::runOnOperation() {
                 dst);
           }
           auto src = call->getOperand(1);
-          if (auto mt = src.getType().dyn_cast<MemRefType>()) {
+          if (auto mt = llvm::dyn_cast<MemRefType>(src.getType())) {
             src = bz.create<polygeist::Memref2PointerOp>(
                 call->getLoc(),
                 LLVM::LLVMPointerType::get(mt.getElementType(),
@@ -859,7 +859,7 @@ void ConvertCudaRTtoCPU::runOnOperation() {
           OpBuilder bz(call);
           auto falsev = bz.create<ConstantIntOp>(call->getLoc(), false, 1);
           auto dst = call->getOperand(0);
-          if (auto mt = dst.getType().dyn_cast<MemRefType>()) {
+          if (auto mt = llvm::dyn_cast<MemRefType>(dst.getType())) {
             dst = bz.create<polygeist::Memref2PointerOp>(
                 call->getLoc(),
                 LLVM::LLVMPointerType::get(mt.getElementType(),

--- a/lib/polygeist/Passes/ParallelLower.cpp
+++ b/lib/polygeist/Passes/ParallelLower.cpp
@@ -596,7 +596,7 @@ void ParallelLower::runOnOperation() {
 
     container.walk([&](mlir::memref::AllocaOp alop) {
       if (auto ia =
-              alop.getType().getMemorySpace().dyn_cast_or_null<IntegerAttr>())
+              dyn_cast_or_null<IntegerAttr>(alop.getType().getMemorySpace()))
         if (ia.getValue() == 5) {
           builder.setInsertionPointToStart(blockB);
           auto newAlloca = builder.create<memref::AllocaOp>(

--- a/lib/polygeist/Passes/PolygeistMem2Reg.cpp
+++ b/lib/polygeist/Passes/PolygeistMem2Reg.cpp
@@ -1102,7 +1102,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     auto pair = list.front();
     auto val = pair.first;
     if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
-      if (auto ia = MT.getMemorySpace().dyn_cast_or_null<IntegerAttr>())
+      if (auto ia = llvm::dyn_cast_or_null<IntegerAttr>(MT.getMemorySpace()))
         SharedMemAddr = ia.getValue() == 5;
     } else {
       auto PT = llvm::dyn_cast<LLVM::LLVMPointerType>(val.getType());

--- a/lib/polygeist/Passes/PolygeistMem2Reg.cpp
+++ b/lib/polygeist/Passes/PolygeistMem2Reg.cpp
@@ -45,8 +45,8 @@ using namespace polygeist;
 enum class Match { Exact, Maybe, None };
 
 bool operator<(Value lhs, Value rhs) {
-  if (auto lhsBA = lhs.dyn_cast<BlockArgument>()) {
-    if (auto rhsBA = rhs.dyn_cast<BlockArgument>()) {
+  if (auto lhsBA = llvm::dyn_cast<BlockArgument>(lhs)) {
+    if (auto rhsBA = llvm::dyn_cast<BlockArgument>(rhs)) {
       if (lhsBA.getOwner() != rhsBA.getOwner())
         return lhsBA.getOwner() < rhsBA.getOwner();
       else
@@ -56,7 +56,7 @@ bool operator<(Value lhs, Value rhs) {
     }
   }
   auto lhsOR = lhs.cast<OpResult>();
-  if (auto rhsBA = rhs.dyn_cast<BlockArgument>()) {
+  if (auto rhsBA = llvm::dyn_cast<BlockArgument>(rhs)) {
     return false;
   } else {
     auto rhsOR = rhs.cast<OpResult>();
@@ -502,7 +502,7 @@ public:
           !exOp->isAncestor(values[0].getDefiningOp())) {
         return values[0];
       }
-      if (auto ba = values[0].dyn_cast<BlockArgument>())
+      if (auto ba = llvm::dyn_cast<BlockArgument>(values[0]))
         if (!exOp->isAncestor(ba.getOwner()->getParentOp())) {
           return values[0];
         }
@@ -1083,7 +1083,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   std::set<mlir::Operation *> allStoreOps;
 
   Type elType;
-  if (auto MT = AI.getType().dyn_cast<MemRefType>())
+  if (auto MT = llvm::dyn_cast<MemRefType>(AI.getType()))
     elType = MT.getElementType();
   else
     elType = AI.getType().cast<LLVM::LLVMPointerType>().getElementType();
@@ -1101,11 +1101,11 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   while (list.size()) {
     auto pair = list.front();
     auto val = pair.first;
-    if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+    if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
       if (auto ia = MT.getMemorySpace().dyn_cast_or_null<IntegerAttr>())
         SharedMemAddr = ia.getValue() == 5;
     } else {
-      auto PT = val.getType().dyn_cast<LLVM::LLVMPointerType>();
+      auto PT = llvm::dyn_cast<LLVM::LLVMPointerType>(val.getType());
       SharedMemAddr = PT.getAddressSpace() == 5;
     }
     auto modified = pair.second;
@@ -1707,7 +1707,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
 
     Value maybeblockArg =
         valueAtStartOfBlock.find(block)->second->materialize(false);
-    auto blockArg = maybeblockArg.dyn_cast<BlockArgument>();
+    auto blockArg = llvm::dyn_cast<BlockArgument>(maybeblockArg);
     assert(blockArg && blockArg.getOwner() == block);
 
     SetVector<Block *> prepred(block->getPredecessors().begin(),

--- a/tools/cgeist/Lib/CGCall.cc
+++ b/tools/cgeist/Lib/CGCall.cc
@@ -34,7 +34,7 @@ static mlir::Value castCallerMemRefArg(mlir::Value callerArg,
   mlir::OpBuilder::InsertionGuard guard(b);
   mlir::Type callerArgType = callerArg.getType();
 
-  if (MemRefType dstTy = calleeArgType.dyn_cast_or_null<MemRefType>()) {
+  if (MemRefType dstTy = llvm::dyn_cast_or_null<MemRefType>(calleeArgType)) {
     MemRefType srcTy = llvm::dyn_cast<MemRefType>(callerArgType);
     if (srcTy && dstTy.getElementType() == srcTy.getElementType() &&
         dstTy.getMemorySpace() == srcTy.getMemorySpace()) {

--- a/tools/cgeist/Lib/CGCall.cc
+++ b/tools/cgeist/Lib/CGCall.cc
@@ -35,7 +35,7 @@ static mlir::Value castCallerMemRefArg(mlir::Value callerArg,
   mlir::Type callerArgType = callerArg.getType();
 
   if (MemRefType dstTy = calleeArgType.dyn_cast_or_null<MemRefType>()) {
-    MemRefType srcTy = callerArgType.dyn_cast<MemRefType>();
+    MemRefType srcTy = llvm::dyn_cast<MemRefType>(callerArgType);
     if (srcTy && dstTy.getElementType() == srcTy.getElementType() &&
         dstTy.getMemorySpace() == srcTy.getMemorySpace()) {
       auto srcShape = srcTy.getShape();
@@ -126,7 +126,7 @@ ValueCategory MLIRScanner::CallHelper(
     QualType aType = (i == 0 && a == nullptr) ? objType : a->getType();
 
     auto expectedType = Glob.getMLIRType(aType, &isArray);
-    if (auto PT = arg.val.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    if (auto PT = llvm::dyn_cast<LLVM::LLVMPointerType>(arg.val.getType())) {
       if (PT.getAddressSpace() == 5)
         arg.val = builder.create<LLVM::AddrSpaceCastOp>(
             loc, LLVM::LLVMPointerType::get(PT.getElementType(), 0), arg.val);
@@ -174,7 +174,7 @@ ValueCategory MLIRScanner::CallHelper(
           val = builder.create<polygeist::Pointer2MemrefOp>(loc, expectedType,
                                                             val);
         }
-        if (auto prevTy = val.getType().dyn_cast<mlir::IntegerType>()) {
+        if (auto prevTy = llvm::dyn_cast<mlir::IntegerType>(val.getType())) {
           auto ipostTy = expectedType.cast<mlir::IntegerType>();
           if (prevTy != ipostTy)
             val = builder.create<arith::TruncIOp>(loc, ipostTy, val);
@@ -258,7 +258,7 @@ ValueCategory MLIRScanner::CallHelper(
     assert(l0.isReference);
     mlir::Value blocks[3];
     mlir::Value val = l0.val;
-    if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+    if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
       if (MT.getElementType().isa<LLVM::LLVMStructType>() &&
           MT.getShape().size() == 1) {
         val = builder.create<polygeist::Memref2PointerOp>(
@@ -269,7 +269,7 @@ ValueCategory MLIRScanner::CallHelper(
       }
     }
     for (int i = 0; i < 3; i++) {
-      if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
         mlir::Value idx[] = {getConstantIndex(0), getConstantIndex(i)};
         assert(MT.getShape().size() == 2);
         blocks[i] = builder.create<IndexCastOp>(
@@ -294,7 +294,7 @@ ValueCategory MLIRScanner::CallHelper(
     assert(t0.isReference);
     mlir::Value threads[3];
     val = t0.val;
-    if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+    if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
       if (MT.getElementType().isa<LLVM::LLVMStructType>() &&
           MT.getShape().size() == 1) {
         val = builder.create<polygeist::Memref2PointerOp>(
@@ -305,7 +305,7 @@ ValueCategory MLIRScanner::CallHelper(
       }
     }
     for (int i = 0; i < 3; i++) {
-      if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
         mlir::Value idx[] = {getConstantIndex(0), getConstantIndex(i)};
         assert(MT.getShape().size() == 2);
         threads[i] = builder.create<IndexCastOp>(
@@ -383,10 +383,10 @@ mlir::Value MLIRScanner::getLLVM(Expr *E, bool isRef) {
   if (isReference) {
     assert(sub.isReference);
     mlir::Value val = sub.val;
-    if (auto mt = val.getType().dyn_cast<MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<MemRefType>(val.getType())) {
       val =
           builder.create<polygeist::Memref2PointerOp>(loc, getOpaquePtr(), val);
-    } else if (auto pt = val.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    } else if (auto pt = llvm::dyn_cast<LLVM::LLVMPointerType>(val.getType())) {
       if (!pt.isOpaque())
         val = builder.create<LLVM::BitcastOp>(loc, getOpaquePtr(), val);
     }
@@ -441,9 +441,9 @@ mlir::Value MLIRScanner::getLLVM(Expr *E, bool isRef) {
     val = sub.val;
     ct = Glob.CGM.getContext().getLValueReferenceType(E->getType());
   }
-  if (auto mt = val.getType().dyn_cast<MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<MemRefType>(val.getType())) {
     val = builder.create<polygeist::Memref2PointerOp>(loc, getOpaquePtr(), val);
-  } else if (auto pt = val.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+  } else if (auto pt = llvm::dyn_cast<LLVM::LLVMPointerType>(val.getType())) {
     if (!pt.isOpaque())
       val = builder.create<LLVM::BitcastOp>(loc, getOpaquePtr(), val);
   }
@@ -498,7 +498,7 @@ MLIRScanner::EmitClangBuiltinCallExpr(clang::CallExpr *expr) {
         loc, mlir::IndexType::get(builder.getContext()), count);
     auto ty = getMLIRType(expr->getType());
     mlir::Value alloc;
-    if (auto mt = ty.dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(ty)) {
       auto shape = std::vector<int64_t>(mt.getShape());
       mlir::Value args[1] = {count};
       alloc = builder.create<mlir::memref::AllocOp>(loc, mt, args);
@@ -1288,7 +1288,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
                     loc, offset,
                     builder.create<ConstantIndexOp>(loc, elemSize));
                 // assert(!dstArray);
-                if (auto mt = dst.getType().dyn_cast<MemRefType>()) {
+                if (auto mt = llvm::dyn_cast<MemRefType>(dst.getType())) {
                   auto shape = std::vector<int64_t>(mt.getShape());
                   shape[0] = ShapedType::kDynamic;
                   auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
@@ -1677,7 +1677,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
           builder.create<mlir::LLVM::CallOp>(loc, strcmpF, args).getResult();
     } else {
       mlir::Value fn = Visit(expr->getCallee()).getValue(loc, builder);
-      if (auto MT = fn.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = llvm::dyn_cast<MemRefType>(fn.getType())) {
         fn = builder.create<polygeist::Memref2PointerOp>(
             loc, LLVM::LLVMPointerType::get(MT.getElementType(), 0), fn);
       }
@@ -1688,14 +1688,14 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       SmallVector<mlir::Type, 1> argtys;
       bool needsChange = false;
       for (auto FT : PTF.getParams()) {
-        if (auto mt = FT.dyn_cast<MemRefType>()) {
+        if (auto mt = llvm::dyn_cast<MemRefType>(FT)) {
           argtys.push_back(LLVM::LLVMPointerType::get(mt.getElementType(), 0));
           needsChange = true;
         } else
           argtys.push_back(FT);
       }
       auto rt = PTF.getReturnType();
-      if (auto mt = rt.dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(rt)) {
         rt = LLVM::LLVMPointerType::get(mt.getElementType(), 0);
         needsChange = true;
       }
@@ -1788,7 +1788,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
           */
         }
         i++;
-        if (auto mt = v.getType().dyn_cast<MemRefType>()) {
+        if (auto mt = llvm::dyn_cast<MemRefType>(v.getType())) {
           v = builder.create<polygeist::Memref2PointerOp>(
               loc, LLVM::LLVMPointerType::get(mt.getElementType(), 0), v);
         }
@@ -1807,7 +1807,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
         assert(l0.isReference);
         mlir::Value val = l0.val;
         mlir::Value blocks[3];
-        if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+        if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
           if (MT.getElementType().isa<LLVM::LLVMStructType>() &&
               MT.getShape().size() == 1) {
             val = builder.create<polygeist::Memref2PointerOp>(
@@ -1818,7 +1818,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
           }
         }
         for (int i = 0; i < 3; i++) {
-          if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+          if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
             mlir::Value idx[] = {getConstantIndex(0), getConstantIndex(i)};
             assert(MT.getShape().size() == 2);
             blocks[i] = builder.create<IndexCastOp>(
@@ -1846,7 +1846,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
         assert(t0.isReference);
         mlir::Value threads[3];
         val = t0.val;
-        if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+        if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
           if (MT.getElementType().isa<LLVM::LLVMStructType>() &&
               MT.getShape().size() == 1) {
             val = builder.create<polygeist::Memref2PointerOp>(
@@ -1857,7 +1857,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
           }
         }
         for (int i = 0; i < 3; i++) {
-          if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+          if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
             mlir::Value idx[] = {getConstantIndex(0), getConstantIndex(i)};
             assert(MT.getShape().size() == 2);
             threads[i] = builder.create<IndexCastOp>(

--- a/tools/cgeist/Lib/CGStmt.cc
+++ b/tools/cgeist/Lib/CGStmt.cc
@@ -249,14 +249,14 @@ ValueCategory MLIRScanner::VisitForStmt(clang::ForStmt *fors) {
     if (auto *s = fors->getCond()) {
       auto condRes = Visit(s);
       auto cond = condRes.getValue(loc, builder);
-      if (auto mt = cond.getType().dyn_cast<mlir::MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<mlir::MemRefType>(cond.getType())) {
         cond = builder.create<polygeist::Memref2PointerOp>(
             loc,
             LLVM::LLVMPointerType::get(mt.getElementType(),
                                        mt.getMemorySpaceAsInt()),
             cond);
       }
-      if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+      if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
         auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
         cond = builder.create<mlir::LLVM::ICmpOp>(
             loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -342,7 +342,7 @@ ValueCategory MLIRScanner::VisitCXXForRangeStmt(clang::CXXForRangeStmt *fors) {
   if (auto *s = fors->getCond()) {
     auto condRes = Visit(s);
     auto cond = condRes.getValue(loc, builder);
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       cond = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -742,7 +742,7 @@ ValueCategory MLIRScanner::VisitDoStmt(clang::DoStmt *fors) {
   if (auto *s = fors->getCond()) {
     auto condRes = Visit(s);
     auto cond = condRes.getValue(loc, builder);
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       cond = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -805,7 +805,7 @@ ValueCategory MLIRScanner::VisitWhileStmt(clang::WhileStmt *stmt) {
   if (auto *s = stmt->getCond()) {
     auto condRes = Visit(s);
     auto cond = condRes.getValue(loc, builder);
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       cond = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -849,11 +849,11 @@ ValueCategory MLIRScanner::VisitIfStmt(clang::IfStmt *stmt) {
 
   auto oldpoint = builder.getInsertionPoint();
   auto *oldblock = builder.getInsertionBlock();
-  if (auto LT = cond.getType().dyn_cast<MemRefType>()) {
+  if (auto LT = llvm::dyn_cast<MemRefType>(cond.getType())) {
     cond = builder.create<polygeist::Memref2PointerOp>(
         loc, LLVM::LLVMPointerType::get(builder.getI8Type()), cond);
   }
-  if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
     auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
     cond = builder.create<mlir::LLVM::ICmpOp>(
         loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -1164,7 +1164,7 @@ ValueCategory MLIRScanner::VisitReturnStmt(clang::ReturnStmt *stmt) {
       }
 
       auto postTy = returnVal.getType().cast<MemRefType>().getElementType();
-      if (auto prevTy = val.getType().dyn_cast<mlir::IntegerType>()) {
+      if (auto prevTy = llvm::dyn_cast<mlir::IntegerType>(val.getType())) {
         auto ipostTy = postTy.cast<mlir::IntegerType>();
         if (prevTy != ipostTy) {
           val = builder.create<arith::TruncIOp>(loc, ipostTy, val);

--- a/tools/cgeist/Lib/ValueCategory.cc
+++ b/tools/cgeist/Lib/ValueCategory.cc
@@ -40,7 +40,7 @@ mlir::Value ValueCategory::getValue(mlir::Location loc,
   if (val.getType().isa<mlir::LLVM::LLVMPointerType>()) {
     return builder.create<mlir::LLVM::LoadOp>(loc, val);
   }
-  if (auto mt = val.getType().dyn_cast<mlir::MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<mlir::MemRefType>(val.getType())) {
     assert(mt.getShape().size() == 1 && "must have shape 1");
     auto c0 = builder.create<ConstantIndexOp>(loc, 0);
     return builder.create<memref::LoadOp>(loc, val,
@@ -53,7 +53,7 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
                           mlir::Value toStore) const {
   assert(isReference && "must be a reference");
   assert(val && "expect not-null");
-  if (auto pt = val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  if (auto pt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(val.getType())) {
     if (auto p2m = toStore.getDefiningOp<polygeist::Pointer2MemrefOp>()) {
       if (pt.getElementType() == p2m.getSource().getType())
         toStore = p2m.getSource();
@@ -64,9 +64,9 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
       }
     }
     if (toStore.getType() != pt.getElementType()) {
-      if (auto mt = toStore.getType().dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(toStore.getType())) {
         if (auto spt =
-                pt.getElementType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+                llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(pt.getElementType())) {
           if (mt.getElementType() != spt.getElementType()) {
             // llvm::errs() << " func: " <<
             // val.getDefiningOp()->getParentOfType<FuncOp>() << "\n";
@@ -84,13 +84,12 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
     }
     return;
   }
-  if (auto mt = val.getType().dyn_cast<MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<MemRefType>(val.getType())) {
     assert(mt.getShape().size() == 1 && "must have size 1");
-    if (auto PT = toStore.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      if (auto MT = val.getType()
+    if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(toStore.getType())) {
+      if (auto MT = llvm::dyn_cast<mlir::MemRefType>(val.getType()
                         .cast<MemRefType>()
-                        .getElementType()
-                        .dyn_cast<mlir::MemRefType>()) {
+                        .getElementType())) {
         assert(MT.getShape().size() == 1);
         assert(MT.getShape()[0] == ShapedType::kDynamic);
         assert(MT.getElementType() == PT.getElementType());
@@ -156,10 +155,10 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
     assert(toStore.isReference);
     auto zeroIndex = builder.create<ConstantIndexOp>(loc, 0);
 
-    if (auto smt = toStore.val.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto smt = llvm::dyn_cast<mlir::MemRefType>(toStore.val.getType())) {
       assert(smt.getShape().size() <= 2);
 
-      if (auto mt = val.getType().dyn_cast<mlir::MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<mlir::MemRefType>(val.getType())) {
         assert(smt.getElementType() == mt.getElementType());
         if (mt.getShape().size() != smt.getShape().size()) {
           llvm::errs() << " val: " << val << " tsv: " << toStore.val << "\n";
@@ -180,7 +179,7 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
       } else {
         auto pt = val.getType().cast<mlir::LLVM::LLVMPointerType>();
         mlir::Type elty;
-        if (auto at = pt.getElementType().dyn_cast<LLVM::LLVMArrayType>()) {
+        if (auto at = llvm::dyn_cast<LLVM::LLVMArrayType>(pt.getElementType())) {
           elty = at.getElementType();
           if (smt.getShape().back() != at.getNumElements()) {
             llvm::errs() << " pt: " << pt << " smt: " << smt << "\n";
@@ -191,7 +190,7 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
           }
           assert(smt.getShape().back() == at.getNumElements());
         } else {
-          auto st = pt.getElementType().dyn_cast<LLVM::LLVMStructType>();
+          auto st = llvm::dyn_cast<LLVM::LLVMStructType>(pt.getElementType());
           elty = st.getBody()[0];
           assert(smt.getShape().back() == (ssize_t)st.getBody().size());
         }
@@ -221,16 +220,16 @@ void ValueCategory::store(mlir::Location loc, mlir::OpBuilder &builder,
               builder.create<mlir::LLVM::GEPOp>(loc, elty, val, lidx));
         }
       }
-    } else if (auto smt = val.getType().dyn_cast<mlir::MemRefType>()) {
+    } else if (auto smt = llvm::dyn_cast<mlir::MemRefType>(val.getType())) {
       assert(smt.getShape().size() <= 2);
 
       auto pt = toStore.val.getType().cast<LLVM::LLVMPointerType>();
       mlir::Type elty;
-      if (auto at = pt.getElementType().dyn_cast<LLVM::LLVMArrayType>()) {
+      if (auto at = llvm::dyn_cast<LLVM::LLVMArrayType>(pt.getElementType())) {
         elty = at.getElementType();
         assert(smt.getShape().back() == at.getNumElements());
       } else {
-        auto st = pt.getElementType().dyn_cast<LLVM::LLVMStructType>();
+        auto st = llvm::dyn_cast<LLVM::LLVMStructType>(pt.getElementType());
         elty = st.getBody()[0];
         assert(smt.getShape().back() == (ssize_t)st.getBody().size());
       }

--- a/tools/cgeist/Lib/clang-mlir.cc
+++ b/tools/cgeist/Lib/clang-mlir.cc
@@ -77,7 +77,7 @@ ValueCategory MLIRScanner::createComplexFloat(mlir::Location loc,
   OpBuilder abuilder(builder.getContext());
   abuilder.setInsertionPointToStart(allocationScope);
   mlir::Value result;
-  if (auto MT = elty.dyn_cast<MemRefType>()) {
+  if (auto MT = llvm::dyn_cast<MemRefType>(elty)) {
     mt = elty;
     elty = MT.getElementType();
     ref = true;
@@ -109,7 +109,7 @@ ValueCategory MLIRScanner::createComplexFloat(mlir::Location loc,
 
 ValueCategory MLIRScanner::getComplexPartRef(mlir::Location loc,
                                              mlir::Value val, int fnum) {
-  if (auto MT = val.getType().dyn_cast<MemRefType>()) {
+  if (auto MT = llvm::dyn_cast<MemRefType>(val.getType())) {
     if (MT.getElementType().isa<LLVM::LLVMStructType>() &&
         MT.getShape().size() == 1) {
       val = builder.create<polygeist::Memref2PointerOp>(
@@ -119,7 +119,7 @@ ValueCategory MLIRScanner::getComplexPartRef(mlir::Location loc,
           val);
     }
   }
-  if (auto mt = val.getType().dyn_cast<mlir::MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<mlir::MemRefType>(val.getType())) {
     auto shape = std::vector<int64_t>(mt.getShape());
     assert(shape.size() == 2);
     shape.erase(shape.begin());
@@ -135,9 +135,9 @@ ValueCategory MLIRScanner::getComplexPartRef(mlir::Location loc,
     si = builder.create<polygeist::SubIndexOp>(loc, mt1, si,
                                                getConstantIndex(fnum));
     return ValueCategory(si, /*isReference*/ true);
-  } else if (auto PT = val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  } else if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(val.getType())) {
     mlir::Type ET;
-    if (auto ST = PT.getElementType().dyn_cast<mlir::LLVM::LLVMStructType>()) {
+    if (auto ST = llvm::dyn_cast<mlir::LLVM::LLVMStructType>(PT.getElementType())) {
       ET = ST.getBody()[fnum];
     } else {
       ET = PT.getElementType()
@@ -159,7 +159,7 @@ ValueCategory MLIRScanner::getComplexPartRef(mlir::Location loc,
 /// Get real (fnum = 0) or imaginary (fnum = 1) part of a complex float
 mlir::Value MLIRScanner::getComplexPart(mlir::Location loc, mlir::Value complex,
                                         int fnum) {
-  if (auto ft = complex.getType().dyn_cast<mlir::FloatType>()) {
+  if (auto ft = llvm::dyn_cast<mlir::FloatType>(complex.getType())) {
     if (fnum == 0)
       return complex;
     else
@@ -170,9 +170,9 @@ mlir::Value MLIRScanner::getComplexPart(mlir::Location loc, mlir::Value complex,
     return builder.create<LLVM::ExtractValueOp>(loc, complex, fnum);
   }
   auto ref = getComplexPartRef(loc, complex, fnum).val;
-  if (auto mt = ref.getType().dyn_cast<mlir::MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<mlir::MemRefType>(ref.getType())) {
     return builder.create<mlir::memref::LoadOp>(loc, ref);
-  } else if (auto PT = ref.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  } else if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(ref.getType())) {
     return builder.create<mlir::LLVM::LoadOp>(loc, ref);
   } else {
     assert(0);
@@ -415,12 +415,12 @@ void MLIRScanner::init(mlir::func::FuncOp function, const FunctionDecl *fd) {
     if (D->getParent()->isUnion() && D->isDefaulted()) {
       mlir::Value V = ThisVal.val;
       assert(V);
-      if (auto MT = V.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = llvm::dyn_cast<MemRefType>(V.getType())) {
         V = builder.create<polygeist::Memref2PointerOp>(
             loc, LLVM::LLVMPointerType::get(MT.getElementType()), V);
       }
       mlir::Value src = function.getArgument(1);
-      if (auto MT = src.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = llvm::dyn_cast<MemRefType>(src.getType())) {
         src = builder.create<polygeist::Memref2PointerOp>(
             loc, LLVM::LLVMPointerType::get(MT.getElementType()), src);
       }
@@ -608,7 +608,7 @@ MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
       builder.create<ConstantIntOp>(exprLoc, indices[0], 32),
   };
 
-  if (const auto pt = et.dyn_cast<LLVM::LLVMPointerType>()) {
+  if (const auto pt = llvm::dyn_cast<LLVM::LLVMPointerType>(et)) {
     auto pt0 =
         pt.getElementType().cast<mlir::LLVM::LLVMArrayType>().getElementType();
     base.val = builder.create<mlir::LLVM::GEPOp>(
@@ -616,7 +616,7 @@ MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
         base.val, idxs);
 
     result = ValueCategory(base.val, true);
-  } else if (const auto mt = et.dyn_cast<MemRefType>()) {
+  } else if (const auto mt = llvm::dyn_cast<MemRefType>(et)) {
     auto shape = std::vector<int64_t>(mt.getShape());
 
     if (shape.size() == 1) {
@@ -642,7 +642,7 @@ MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
 
 ValueCategory MLIRScanner::VisitConstantExpr(clang::ConstantExpr *expr) {
   auto sv = Visit(expr->getSubExpr());
-  if (auto ty = getMLIRType(expr->getType()).dyn_cast<mlir::IntegerType>()) {
+  if (auto ty = llvm::dyn_cast<mlir::IntegerType>(getMLIRType(expr->getType()))) {
     if (expr->hasAPValueResult()) {
       return ValueCategory(builder.create<arith::ConstantIntOp>(
                                getMLIRLocation(expr->getExprLoc()),
@@ -699,7 +699,7 @@ MLIRScanner::VisitImaginaryLiteral(clang::ImaginaryLiteral *expr) {
   auto loc = getMLIRLocation(expr->getExprLoc());
   auto convertedType = getMLIRType(expr->getType());
   mlir::FloatType fty;
-  if (auto mt = convertedType.dyn_cast<MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<MemRefType>(convertedType)) {
     auto elty = mt.getElementType();
     if (auto ST = dyn_cast<mlir::LLVM::LLVMStructType>(elty)) {
       fty = ST.getBody()[0].cast<FloatType>();
@@ -743,21 +743,21 @@ MLIRScanner::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr *decl) {
   auto Mty = getMLIRType(decl->getType());
   auto loc = getMLIRLocation(decl->getExprLoc());
 
-  if (auto FT = Mty.dyn_cast<mlir::FloatType>())
+  if (auto FT = llvm::dyn_cast<mlir::FloatType>(Mty))
     return ValueCategory(builder.create<ConstantFloatOp>(
                              loc, APFloat(FT.getFloatSemantics(), "0"), FT),
                          /*isReference*/ false);
-  if (auto IT = Mty.dyn_cast<mlir::IntegerType>())
+  if (auto IT = llvm::dyn_cast<mlir::IntegerType>(Mty))
     return ValueCategory(builder.create<ConstantIntOp>(loc, 0, IT),
                          /*isReference*/ false);
-  if (auto MT = Mty.dyn_cast<mlir::MemRefType>())
+  if (auto MT = llvm::dyn_cast<mlir::MemRefType>(Mty))
     return ValueCategory(
         builder.create<polygeist::Pointer2MemrefOp>(
             loc, MT,
             builder.create<mlir::LLVM::ZeroOp>(
                 loc, LLVM::LLVMPointerType::get(builder.getI8Type()))),
         false);
-  if (auto PT = Mty.dyn_cast<mlir::LLVM::LLVMPointerType>())
+  if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(Mty))
     return ValueCategory(builder.create<mlir::LLVM::ZeroOp>(loc, PT), false);
   for (auto child : decl->children()) {
     child->dump();
@@ -777,7 +777,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
 
   bool inner = false;
   if (isa<RecordType>(PTT) || isa<clang::ComplexType>(PTT)) {
-    if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<MemRefType>(toInit.getType())) {
       inner = true;
     }
   }
@@ -794,7 +794,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
     if (InitListExpr *initListExpr = dyn_cast<InitListExpr>(expr)) {
 
       if (inner) {
-        if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+        if (auto mt = llvm::dyn_cast<MemRefType>(toInit.getType())) {
           auto shape = std::vector<int64_t>(mt.getShape());
           shape.erase(shape.begin());
           auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
@@ -807,17 +807,17 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
 
       unsigned num = 0;
       if (initListExpr->hasArrayFiller()) {
-        if (auto MT = toInit.getType().dyn_cast<MemRefType>()) {
+        if (auto MT = llvm::dyn_cast<MemRefType>(toInit.getType())) {
           auto shape = MT.getShape();
           assert(shape.size() > 0);
           assert(shape[0] != ShapedType::kDynamic);
           num = shape[0];
         } else if (auto PT =
-                       toInit.getType().dyn_cast<LLVM::LLVMPointerType>()) {
-          if (auto AT = PT.getElementType().dyn_cast<LLVM::LLVMArrayType>()) {
+                       llvm::dyn_cast<LLVM::LLVMPointerType>(toInit.getType())) {
+          if (auto AT = llvm::dyn_cast<LLVM::LLVMArrayType>(PT.getElementType())) {
             num = AT.getNumElements();
           } else if (auto AT =
-                         PT.getElementType().dyn_cast<LLVM::LLVMStructType>()) {
+                         llvm::dyn_cast<LLVM::LLVMStructType>(PT.getElementType())) {
             num = AT.getBody().size();
           } else {
             toInit.getType().dump();
@@ -834,7 +834,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
       SmallVector<char> attrs;
       bool allSub = true;
 
-      if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(toInit.getType())) {
         auto shape = std::vector<int64_t>(mt.getShape());
         if (shape.size() == 0) {
           auto ET = mt.getElementType();
@@ -853,7 +853,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
       for (unsigned i = 0, e = num; i < e; ++i) {
 
         mlir::Value next;
-        if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+        if (auto mt = llvm::dyn_cast<MemRefType>(toInit.getType())) {
           auto shape = std::vector<int64_t>(mt.getShape());
           assert(shape.size() > 0);
           shape[0] = ShapedType::kDynamic;
@@ -866,9 +866,9 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
           auto PT = toInit.getType().cast<LLVM::LLVMPointerType>();
           auto ET = PT.getElementType();
           mlir::Type nextType;
-          if (auto ST = ET.dyn_cast<LLVM::LLVMStructType>())
+          if (auto ST = llvm::dyn_cast<LLVM::LLVMStructType>(ET))
             nextType = ST.getBody()[i];
-          else if (auto AT = ET.dyn_cast<LLVM::LLVMArrayType>())
+          else if (auto AT = llvm::dyn_cast<LLVM::LLVMArrayType>(ET))
             nextType = AT.getElementType();
           else
             assert(0 && "unknown inner type");
@@ -900,7 +900,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
       }
       if (!allSub)
         return mlir::DenseElementsAttr();
-      if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(toInit.getType())) {
         std::vector<int64_t> shape(mt.getShape());
         assert(shape.size() > 0);
         shape[0] = num;
@@ -915,7 +915,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
       ValueCategory(toInit, /*isReference*/ true)
           .store(loc, builder, sub, isArray);
       if (!sub.isReference)
-        if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+        if (auto mt = llvm::dyn_cast<MemRefType>(toInit.getType())) {
           if (auto cop = sub.val.getDefiningOp<ConstantIntOp>())
             return DenseElementsAttr::get(
                 RankedTensorType::get(std::vector<int64_t>({1}),
@@ -1246,11 +1246,11 @@ ValueCategory MLIRScanner::VisitLambdaExpr(clang::LambdaExpr *expr) {
   bool isArray = false;
   Glob.getMLIRType(expr->getCallOperator()->getThisObjectType(), &isArray);
 
-  if (auto PT = t.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(t)) {
     LLVMABI = true;
     t = PT.getElementType();
   }
-  if (auto mt = t.dyn_cast<MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<MemRefType>(t)) {
     auto shape = std::vector<int64_t>(mt.getShape());
     if (!isArray) {
       t = mt.getElementType();
@@ -1313,7 +1313,7 @@ ValueCategory MLIRScanner::VisitLambdaExpr(clang::LambdaExpr *expr) {
 
       auto val = result.val;
 
-      if (auto mt = val.getType().dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(val.getType())) {
         auto shape = std::vector<int64_t>(mt.getShape());
         shape[0] = ShapedType::kDynamic;
         val = builder.create<memref::CastOp>(
@@ -1401,8 +1401,8 @@ ValueCategory MLIRScanner::VisitCXXNewExpr(clang::CXXNewExpr *expr) {
   if (!expr->placement_arguments().empty()) {
     mlir::Value val =
         Visit(*expr->placement_arg_begin()).getValue(loc, builder);
-    if (auto mt = ty.dyn_cast<mlir::MemRefType>()) {
-      if (auto mtin = val.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(ty)) {
+      if (auto mtin = llvm::dyn_cast<mlir::MemRefType>(val.getType())) {
         val = builder.create<polygeist::Memref2PointerOp>(
             loc,
             LLVM::LLVMPointerType::get(mtin.getElementType(),
@@ -1422,7 +1422,7 @@ ValueCategory MLIRScanner::VisitCXXNewExpr(clang::CXXNewExpr *expr) {
                 PT.getAddressSpace()),
             alloc);
     }
-  } else if (auto mt = ty.dyn_cast<mlir::MemRefType>()) {
+  } else if (auto mt = llvm::dyn_cast<mlir::MemRefType>(ty)) {
     auto shape = std::vector<int64_t>(mt.getShape());
     mlir::Value args[1] = {count};
     arrayCons = alloc = builder.create<mlir::memref::AllocOp>(loc, mt, args);
@@ -1509,14 +1509,14 @@ MLIRScanner::VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *expr) {
 
   if (melem.isa<mlir::IntegerType>())
     return ValueCategory(builder.create<ConstantIntOp>(loc, 0, melem), false);
-  else if (auto MT = melem.dyn_cast<mlir::MemRefType>())
+  else if (auto MT = llvm::dyn_cast<mlir::MemRefType>(melem))
     return ValueCategory(
         builder.create<polygeist::Pointer2MemrefOp>(
             loc, MT,
             builder.create<mlir::LLVM::ZeroOp>(
                 loc, LLVM::LLVMPointerType::get(builder.getI8Type()))),
         false);
-  else if (auto PT = melem.dyn_cast<mlir::LLVM::LLVMPointerType>())
+  else if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(melem))
     return ValueCategory(builder.create<mlir::LLVM::ZeroOp>(loc, PT), false);
   else {
     if (!melem.isa<FloatType>())
@@ -1635,7 +1635,7 @@ ValueCategory MLIRScanner::CommonArrayToPointer(mlir::Location loc,
                                                 ValueCategory scalar) {
   assert(scalar.val);
   assert(scalar.isReference);
-  if (auto PT = scalar.val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(scalar.val.getType())) {
     if (PT.getElementType().isa<mlir::LLVM::LLVMPointerType>())
       return ValueCategory(scalar.val, /*isRef*/ false);
     mlir::Value vec[2] = {builder.create<ConstantIntOp>(loc, 0, 32),
@@ -1918,8 +1918,8 @@ MLIRScanner::EmitGPUCallExpr(clang::CallExpr *expr) {
           sub = BC->getSubExpr();
         {
           auto dst = Visit(sub).getValue(loc, builder);
-          if (auto omt = dst.getType().dyn_cast<MemRefType>()) {
-            if (auto mt = omt.getElementType().dyn_cast<MemRefType>()) {
+          if (auto omt = llvm::dyn_cast<MemRefType>(dst.getType())) {
+            if (auto mt = llvm::dyn_cast<MemRefType>(omt.getElementType())) {
               auto shape = std::vector<int64_t>(mt.getShape());
 
               auto elemSize = getTypeSize(
@@ -2133,7 +2133,7 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
     assert(sub.val);
     mlir::Value val = sub.getValue(loc, builder);
 
-    if (auto MT = val.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto MT = llvm::dyn_cast<mlir::MemRefType>(val.getType())) {
       val = builder.create<polygeist::Memref2PointerOp>(
           loc,
           LLVM::LLVMPointerType::get(MT.getElementType(),
@@ -2142,7 +2142,7 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
     }
     auto postTy = getMLIRType(U->getType()).cast<mlir::IntegerType>();
 
-    if (auto LT = val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(val.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       mlir::Value ne = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::eq, val, nullptr_llvm);
@@ -2211,7 +2211,7 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
   case clang::UnaryOperator::Opcode::UO_Minus: {
     mlir::Value val = sub.getValue(loc, builder);
     auto ty = val.getType();
-    if (auto ft = ty.dyn_cast<mlir::FloatType>()) {
+    if (auto ft = llvm::dyn_cast<mlir::FloatType>(ty)) {
       if (auto CI = val.getDefiningOp<ConstantFloatOp>()) {
         auto api = CI.getValue().cast<FloatAttr>().getValue();
         return ValueCategory(builder.create<arith::ConstantOp>(
@@ -2242,7 +2242,7 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
     auto ty = prev.getType();
 
     mlir::Value next;
-    if (auto ft = ty.dyn_cast<mlir::FloatType>()) {
+    if (auto ft = llvm::dyn_cast<mlir::FloatType>(ty)) {
       if (prev.getType() != ty) {
         U->dump();
         llvm::errs() << " ty: " << ty << "prev: " << prev << "\n";
@@ -2252,7 +2252,7 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
           loc, prev,
           builder.create<ConstantFloatOp>(
               loc, APFloat(ft.getFloatSemantics(), "1"), ft));
-    } else if (auto mt = ty.dyn_cast<MemRefType>()) {
+    } else if (auto mt = llvm::dyn_cast<MemRefType>(ty)) {
       auto shape = std::vector<int64_t>(mt.getShape());
       shape[0] = ShapedType::kDynamic;
       auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
@@ -2260,7 +2260,7 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
                                        mt.getMemorySpace());
       next = builder.create<polygeist::SubIndexOp>(loc, mt0, prev,
                                                    getConstantIndex(1));
-    } else if (auto pt = ty.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    } else if (auto pt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(ty)) {
       auto ity = mlir::IntegerType::get(builder.getContext(), 64);
       next = builder.create<LLVM::GEPOp>(
           loc, pt, prev,
@@ -2294,18 +2294,18 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
     auto prev = sub.getValue(loc, builder);
 
     mlir::Value next;
-    if (auto ft = ty.dyn_cast<mlir::FloatType>()) {
+    if (auto ft = llvm::dyn_cast<mlir::FloatType>(ty)) {
       next = builder.create<SubFOp>(
           loc, prev,
           builder.create<ConstantFloatOp>(
               loc, APFloat(ft.getFloatSemantics(), "1"), ft));
-    } else if (auto pt = ty.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    } else if (auto pt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(ty)) {
       auto ity = mlir::IntegerType::get(builder.getContext(), 64);
       next = builder.create<LLVM::GEPOp>(
           loc, pt, prev,
           std::vector<mlir::Value>(
               {builder.create<ConstantIntOp>(loc, ShapedType::kDynamic, ity)}));
-    } else if (auto mt = ty.dyn_cast<MemRefType>()) {
+    } else if (auto mt = llvm::dyn_cast<MemRefType>(ty)) {
       auto shape = std::vector<int64_t>(mt.getShape());
       shape[0] = ShapedType::kDynamic;
       auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
@@ -2404,7 +2404,7 @@ bool hasAffineArith(Operation *op, AffineExpr &expr,
         if (!isa<IndexCastOp>(maybeIndexCast))
           return false;
         auto indexCastOperand = maybeIndexCast->getOperand(0);
-        if (auto blockArg = indexCastOperand.dyn_cast<mlir::BlockArgument>()) {
+        if (auto blockArg = llvm::dyn_cast<mlir::BlockArgument>(indexCastOperand)) {
           if (auto affineForOp = dyn_cast<mlir::affine::AffineForOp>(
                   blockArg.getOwner()->getParentOp()))
             affineForIndVar = affineForOp.getInductionVar();
@@ -2488,7 +2488,7 @@ ValueCategory MLIRScanner::VisitAtomicExpr(clang::AtomicExpr *BO) {
     auto a0 = Visit(BO->getPtr()).getValue(loc, builder);
     auto ret = Visit(BO->getVal1()).dereference(loc, builder);
     mlir::Type ty;
-    if (auto MT = a0.getType().dyn_cast<MemRefType>()) {
+    if (auto MT = llvm::dyn_cast<MemRefType>(a0.getType())) {
       ty = MT.getElementType();
     } else {
       ty = a0.getType().cast<LLVM::LLVMPointerType>().getElementType();
@@ -2533,7 +2533,7 @@ ValueCategory MLIRScanner::VisitAtomicExpr(clang::AtomicExpr *BO) {
         Visit(BO->getVal1()).dereference(loc, builder).getValue(loc, builder);
     auto a2 =
         Visit(BO->getVal2()).dereference(loc, builder).getValue(loc, builder);
-    if (auto mt = a0.getType().dyn_cast<MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<MemRefType>(a0.getType())) {
       a0 = builder.create<polygeist::Memref2PointerOp>(
           loc,
           LLVM::LLVMPointerType::get(mt.getElementType(),
@@ -2593,14 +2593,14 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
   case clang::BinaryOperator::Opcode::BO_LAnd: {
     mlir::Type types[] = {builder.getIntegerType(1)};
     auto cond = lhs.getValue(loc, builder);
-    if (auto mt = cond.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(cond.getType())) {
       cond = builder.create<polygeist::Memref2PointerOp>(
           loc,
           LLVM::LLVMPointerType::get(mt.getElementType(),
                                      mt.getMemorySpaceAsInt()),
           cond);
     }
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       cond = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -2625,7 +2625,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
 
     auto rhs = Visit(BO->getRHS()).getValue(loc, builder);
     assert(rhs != nullptr);
-    if (auto LT = rhs.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(rhs.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       rhs = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, rhs, nullptr_llvm);
@@ -2809,11 +2809,11 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
 
     auto lhs_v = lhs.getValue(loc, builder);
     auto rhs_v = rhs.getValue(loc, builder);
-    if (auto mt = lhs_v.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(lhs_v.getType())) {
       lhs_v = builder.create<polygeist::Memref2PointerOp>(
           loc, LLVM::LLVMPointerType::get(mt.getElementType()), lhs_v);
     }
-    if (auto mt = rhs_v.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(rhs_v.getType())) {
       rhs_v = builder.create<polygeist::Memref2PointerOp>(
           loc, LLVM::LLVMPointerType::get(mt.getElementType()), rhs_v);
     }
@@ -2913,7 +2913,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
     } else if (rhs_v.getType().isa<mlir::MemRefType>()) {
       return emitSubindex(rhs_v, lhs_v);
     } else if (auto pt =
-                   lhs_v.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+                   llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(lhs_v.getType())) {
       return ValueCategory(
           builder.create<LLVM::GEPOp>(loc, pt, lhs_v,
                                       std::vector<mlir::Value>({rhs_v})),
@@ -2937,7 +2937,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
     }
     auto lhs_v = lhs.getValue(loc, builder);
     auto rhs_v = rhs.getValue(loc, builder);
-    if (auto mt = lhs_v.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(lhs_v.getType())) {
       mlir::Type innerType = mt.getElementType();
       auto shape = mt.getShape();
       for (size_t i = 1; i < shape.size(); i++)
@@ -2945,7 +2945,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
       lhs_v = builder.create<polygeist::Memref2PointerOp>(
           loc, LLVM::LLVMPointerType::get(innerType), lhs_v);
     }
-    if (auto mt = rhs_v.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(rhs_v.getType())) {
       mlir::Type innerType = mt.getElementType();
       auto shape = mt.getShape();
       for (size_t i = 1; i < shape.size(); i++)
@@ -2958,8 +2958,8 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
       return ValueCategory(builder.create<SubFOp>(loc, lhs_v, rhs_v),
                            /*isReference*/ false);
     } else if (auto pt =
-                   lhs_v.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      if (auto IT = rhs_v.getType().dyn_cast<mlir::IntegerType>()) {
+                   llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(lhs_v.getType())) {
+      if (auto IT = llvm::dyn_cast<mlir::IntegerType>(rhs_v.getType())) {
         mlir::Value vals[1] = {builder.create<SubIOp>(
             loc, builder.create<ConstantIntOp>(loc, 0, IT.getWidth()), rhs_v)};
         return ValueCategory(
@@ -2990,13 +2990,13 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
     assert(lhs.isReference);
     mlir::Value tostore = rhs.getValue(loc, builder);
     mlir::Type subType;
-    if (auto PT = lhs.val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>())
+    if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(lhs.val.getType()))
       subType = PT.getElementType();
     else
       subType = lhs.val.getType().cast<MemRefType>().getElementType();
     if (tostore.getType() != subType) {
-      if (auto prevTy = tostore.getType().dyn_cast<mlir::IntegerType>()) {
-        if (auto postTy = subType.dyn_cast<mlir::IntegerType>()) {
+      if (auto prevTy = llvm::dyn_cast<mlir::IntegerType>(tostore.getType())) {
+        if (auto postTy = llvm::dyn_cast<mlir::IntegerType>(subType)) {
           bool signedType = true;
           if (auto bit = dyn_cast<clang::BuiltinType>(&*BO->getType())) {
             if (bit->isUnsignedInteger())
@@ -3042,7 +3042,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
       return lhs;
     }
     auto prev = lhs.getValue(loc, builder);
-    if (auto postTy = prev.getType().dyn_cast<mlir::FloatType>()) {
+    if (auto postTy = llvm::dyn_cast<mlir::FloatType>(prev.getType())) {
       mlir::Value rhsV = rhs.getValue(loc, builder);
       auto prevTy = rhsV.getType().cast<mlir::FloatType>();
       if (prevTy == postTy) {
@@ -3054,11 +3054,11 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
       assert(rhsV.getType() == prev.getType());
       result = builder.create<AddFOp>(loc, prev, rhsV);
     } else if (auto pt =
-                   prev.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+                   llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(prev.getType())) {
       result = builder.create<LLVM::GEPOp>(
           loc, pt, prev,
           std::vector<mlir::Value>({rhs.getValue(loc, builder)}));
-    } else if (auto postTy = prev.getType().dyn_cast<mlir::IntegerType>()) {
+    } else if (auto postTy = llvm::dyn_cast<mlir::IntegerType>(prev.getType())) {
       mlir::Value rhsV = rhs.getValue(loc, builder);
       auto prevTy = rhsV.getType().cast<mlir::IntegerType>();
       if (prevTy == postTy) {
@@ -3073,7 +3073,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
       }
       assert(rhsV.getType() == prev.getType());
       result = builder.create<AddIOp>(loc, prev, rhsV);
-    } else if (auto postTy = prev.getType().dyn_cast<mlir::MemRefType>()) {
+    } else if (auto postTy = llvm::dyn_cast<mlir::MemRefType>(prev.getType())) {
       mlir::Value rhsV = rhs.getValue(loc, builder);
       auto shape = std::vector<int64_t>(postTy.getShape());
       shape[0] = ShapedType::kDynamic;
@@ -3303,7 +3303,7 @@ ValueCategory MLIRScanner::CommonFieldLookup(mlir::Location loc,
     }
   }
 
-  if (auto mt = val.getType().dyn_cast<MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<MemRefType>(val.getType())) {
     auto shape = std::vector<int64_t>(mt.getShape());
     if (shape.size() > 1) {
       shape.erase(shape.begin());
@@ -3342,7 +3342,7 @@ ValueCategory MLIRScanner::CommonFieldLookup(mlir::Location loc,
                  << " ST: " << *ST << "\n";
   }
   mlir::Type ET;
-  if (auto ST = PT.getElementType().dyn_cast<mlir::LLVM::LLVMStructType>()) {
+  if (auto ST = llvm::dyn_cast<mlir::LLVM::LLVMStructType>(PT.getElementType())) {
     ET = ST.getBody()[fnum];
   } else {
     ET = PT.getElementType().cast<mlir::LLVM::LLVMArrayType>().getElementType();
@@ -3356,7 +3356,7 @@ ValueCategory MLIRScanner::CommonFieldLookup(mlir::Location loc,
       Glob.CGM.getContext().getPointerType(FD->getType()), &isArray);
   assert(!isArray);
   if (rd->isUnion()) {
-    if (auto PT2 = subType.dyn_cast<LLVM::LLVMPointerType>())
+    if (auto PT2 = llvm::dyn_cast<LLVM::LLVMPointerType>(subType))
       commonGEP = builder.create<mlir::LLVM::BitcastOp>(
           loc,
           mlir::LLVM::LLVMPointerType::get(PT2.getElementType(),
@@ -3372,7 +3372,7 @@ ValueCategory MLIRScanner::CommonFieldLookup(mlir::Location loc,
           commonGEP);
     }
   } else {
-    if (auto mt = subType.dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(subType)) {
       commonGEP = builder.create<polygeist::Pointer2MemrefOp>(
           loc,
           mlir::MemRefType::get(
@@ -3627,7 +3627,7 @@ mlir::Value MLIRScanner::GetAddressOfDerivedClass(
     }
 
     mlir::Value ptr = value;
-    if (auto PT = ptr.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    if (auto PT = llvm::dyn_cast<LLVM::LLVMPointerType>(ptr.getType())) {
       ptr = builder.create<LLVM::BitcastOp>(
           loc,
           LLVM::LLVMPointerType::get(builder.getI8Type(), PT.getAddressSpace()),
@@ -3643,7 +3643,7 @@ mlir::Value MLIRScanner::GetAddressOfDerivedClass(
     mlir::Value idx[] = {Offset};
     ptr = builder.create<LLVM::GEPOp>(loc, ptr.getType(), ptr, idx);
 
-    if (auto PT = nt.dyn_cast<mlir::LLVM::LLVMPointerType>())
+    if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(nt))
       value = builder.create<LLVM::BitcastOp>(
           loc,
           LLVM::LLVMPointerType::get(
@@ -3704,7 +3704,7 @@ mlir::Value MLIRScanner::GetAddressOfBaseClass(
 
     if (subIndex) {
       bool done = false;
-      if (auto mt = value.getType().dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(value.getType())) {
         auto shape = std::vector<int64_t>(mt.getShape());
         if (shape.size() > 1) {
           shape.erase(shape.begin());
@@ -3730,7 +3730,7 @@ mlir::Value MLIRScanner::GetAddressOfBaseClass(
         auto PT = value.getType().cast<LLVM::LLVMPointerType>();
         mlir::Type ET;
         if (auto ST =
-                PT.getElementType().dyn_cast<mlir::LLVM::LLVMStructType>()) {
+                llvm::dyn_cast<mlir::LLVM::LLVMStructType>(PT.getElementType())) {
           ET = ST.getBody()[fnum];
         } else {
           ET = PT.getElementType()
@@ -3744,8 +3744,8 @@ mlir::Value MLIRScanner::GetAddressOfBaseClass(
       }
     }
 
-    auto pt = nt.dyn_cast<mlir::LLVM::LLVMPointerType>();
-    if (auto opt = value.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    auto pt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(nt);
+    if (auto opt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(value.getType())) {
       if (!pt) {
         value = builder.create<polygeist::Pointer2MemrefOp>(loc, nt, value);
       } else {
@@ -3820,14 +3820,14 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     if (E->getCastKind() != clang::CastKind::CK_UncheckedDerivedToBase &&
         !isa<CXXThisExpr>(E->IgnoreParens())) {
       mlir::Value ptr = val;
-      if (auto MT = ptr.getType().dyn_cast<MemRefType>())
+      if (auto MT = llvm::dyn_cast<MemRefType>(ptr.getType()))
         ptr = builder.create<polygeist::Memref2PointerOp>(
             loc, LLVM::LLVMPointerType::get(MT.getElementType()), ptr);
       mlir::Value nullptr_llvm =
           builder.create<mlir::LLVM::ZeroOp>(loc, ptr.getType());
       auto ne = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, ptr, nullptr_llvm);
-      if (auto MT = ptr.getType().dyn_cast<MemRefType>())
+      if (auto MT = llvm::dyn_cast<MemRefType>(ptr.getType()))
         nullptr_llvm =
             builder.create<polygeist::Pointer2MemrefOp>(loc, MT, nullptr_llvm);
       val = builder.create<arith::SelectOp>(loc, ne, ptr, nullptr_llvm);
@@ -3849,12 +3849,12 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     /*
     if (ShouldNullCheckClassCastValue(E)) {
         mlir::Value ptr = val;
-        if (auto MT = ptr.getType().dyn_cast<MemRefType>())
+        if (auto MT = llvm::dyn_cast<MemRefType>(ptr.getType()))
             ptr = builder.create<polygeist::Memref2PointerOp>(loc,
     LLVM::LLVMPointerType::get(MT.getElementType()), ptr); auto nullptr_llvm =
     builder.create<mlir::LLVM::ZeroOp>(loc, ptr.getType()); auto ne =
     builder.create<mlir::LLVM::ICmpOp>( loc, mlir::LLVM::ICmpPredicate::ne, ptr,
-    nullptr_llvm); if (auto MT = ptr.getType().dyn_cast<MemRefType>())
+    nullptr_llvm); if (auto MT = llvm::dyn_cast<MemRefType>(ptr.getType()))
            nullptr_llvm = builder.create<polygeist::Pointer2MemrefOp>(loc, MT,
     nullptr_llvm); val = builder.create<arith::SelectOp>(loc, ne, val,
     nullptr_llvm);
@@ -3869,9 +3869,9 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     }
     auto scalar = se.val;
     assert(se.isReference);
-    if (auto spt = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto spt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(scalar.getType())) {
       auto nt = getMLIRType(E->getType());
-      LLVM::LLVMPointerType pt = nt.dyn_cast<LLVM::LLVMPointerType>();
+      LLVM::LLVMPointerType pt = llvm::dyn_cast<LLVM::LLVMPointerType>(nt);
       if (!pt) {
         return ValueCategory(
             builder.create<polygeist::Pointer2MemrefOp>(loc, nt, scalar),
@@ -3891,11 +3891,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     auto mlirty =
         getMLIRType(Glob.CGM.getContext().getLValueReferenceType(E->getType()));
 
-    if (auto PT = mlirty.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(mlirty)) {
       return ValueCategory(
           builder.create<mlir::polygeist::Memref2PointerOp>(loc, PT, scalar),
           /*isReference*/ true);
-    } else if (auto mt = mlirty.dyn_cast<mlir::MemRefType>()) {
+    } else if (auto mt = llvm::dyn_cast<mlir::MemRefType>(mlirty)) {
       auto ty = mlir::MemRefType::get(mt.getShape(), mt.getElementType(),
                                       MemRefLayoutAttrInterface(),
                                       ut.getMemorySpace());
@@ -3940,7 +3940,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
           if (sr->getDecl()->getIdentifier() &&
               sr->getDecl()->getName() == "polybench_alloc_data") {
             if (auto mt =
-                    getMLIRType(E->getType()).dyn_cast<mlir::MemRefType>()) {
+                    llvm::dyn_cast<mlir::MemRefType>(getMLIRType(E->getType()))) {
               auto shape = std::vector<int64_t>(mt.getShape());
               // shape.erase(shape.begin());
               auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
@@ -3960,7 +3960,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
               (sr->getDecl()->getName() == "malloc" ||
                sr->getDecl()->getName() == "calloc"))
             if (auto mt =
-                    getMLIRType(E->getType()).dyn_cast<mlir::MemRefType>()) {
+                    llvm::dyn_cast<mlir::MemRefType>(getMLIRType(E->getType()))) {
               auto shape = std::vector<int64_t>(mt.getShape());
 
               auto elemSize = getTypeSize(
@@ -4011,9 +4011,9 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
       E->dump();
     }
     auto scalar = se.getValue(loc, builder);
-    if (auto spt = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto spt = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(scalar.getType())) {
       auto nt = getMLIRType(E->getType());
-      LLVM::LLVMPointerType pt = nt.dyn_cast<LLVM::LLVMPointerType>();
+      LLVM::LLVMPointerType pt = llvm::dyn_cast<LLVM::LLVMPointerType>(nt);
       if (!pt) {
         return ValueCategory(
             builder.create<polygeist::Pointer2MemrefOp>(loc, nt, scalar),
@@ -4032,11 +4032,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     auto ut = scalar.getType().cast<mlir::MemRefType>();
     auto mlirty = getMLIRType(E->getType());
 
-    if (auto PT = mlirty.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto PT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(mlirty)) {
       return ValueCategory(
           builder.create<mlir::polygeist::Memref2PointerOp>(loc, PT, scalar),
           /*isReference*/ false);
-    } else if (auto mt = mlirty.dyn_cast<mlir::MemRefType>()) {
+    } else if (auto mt = llvm::dyn_cast<mlir::MemRefType>(mlirty)) {
       auto ty = mlir::MemRefType::get(mt.getShape(), mt.getElementType(),
                                       MemRefLayoutAttrInterface(),
                                       ut.getMemorySpace());
@@ -4260,16 +4260,16 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     mlir::FloatType postScalarTy;
     auto prevTy = complex.getType();
     auto postTy = getMLIRType(E->getType());
-    if (auto mt = postTy.dyn_cast<MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<MemRefType>(postTy)) {
       postScalarTy = mt.getElementType().cast<mlir::FloatType>();
-    } else if (auto ST = postTy.dyn_cast<mlir::LLVM::LLVMStructType>()) {
+    } else if (auto ST = llvm::dyn_cast<mlir::LLVM::LLVMStructType>(postTy)) {
       postScalarTy = ST.getBody()[0].cast<mlir::FloatType>();
     } else {
       assert(0 && "unexpected complex type\n");
     }
-    if (auto mt = prevTy.dyn_cast<MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<MemRefType>(prevTy)) {
       prevScalarTy = mt.getElementType().cast<mlir::FloatType>();
-    } else if (auto ST = prevTy.dyn_cast<mlir::LLVM::LLVMStructType>()) {
+    } else if (auto ST = llvm::dyn_cast<mlir::LLVM::LLVMStructType>(prevTy)) {
       prevScalarTy = ST.getBody()[0].cast<mlir::FloatType>();
     } else {
       assert(0 && "unexpected complex type\n");
@@ -4325,11 +4325,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
   }
   case clang::CastKind::CK_PointerToBoolean: {
     auto scalar = Visit(E->getSubExpr()).getValue(loc, builder);
-    if (auto mt = scalar.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(scalar.getType())) {
       scalar = builder.create<polygeist::Memref2PointerOp>(
           loc, LLVM::LLVMPointerType::get(mt.getElementType()), scalar);
     }
-    if (auto LT = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(scalar.getType())) {
       auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
       auto ne = builder.create<mlir::LLVM::ICmpOp>(
           loc, mlir::LLVM::ICmpPredicate::ne, scalar, nullptr_llvm);
@@ -4342,11 +4342,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
   }
   case clang::CastKind::CK_PointerToIntegral: {
     auto scalar = Visit(E->getSubExpr()).getValue(loc, builder);
-    if (auto mt = scalar.getType().dyn_cast<mlir::MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<mlir::MemRefType>(scalar.getType())) {
       scalar = builder.create<polygeist::Memref2PointerOp>(
           loc, LLVM::LLVMPointerType::get(mt.getElementType()), scalar);
     }
-    if (auto LT = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(scalar.getType())) {
       auto mlirType = getMLIRType(E->getType());
       auto val = builder.create<mlir::LLVM::PtrToIntOp>(loc, mlirType, scalar);
       return ValueCategory(val, /*isReference*/ false);
@@ -4426,7 +4426,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     auto convertedType = getMLIRType(E->getType());
     auto real = sub.getValue(loc, builder);
     mlir::FloatType fty;
-    if (auto mt = convertedType.dyn_cast<MemRefType>()) {
+    if (auto mt = llvm::dyn_cast<MemRefType>(convertedType)) {
       auto elty = mt.getElementType();
       if (auto ST = dyn_cast<mlir::LLVM::LLVMStructType>(elty)) {
         fty = ST.getBody()[0].cast<FloatType>();
@@ -4456,14 +4456,14 @@ MLIRScanner::VisitConditionalOperator(clang::ConditionalOperator *E) {
   auto loc = getMLIRLocation(E->getExprLoc());
   auto cond = Visit(E->getCond()).getValue(loc, builder);
   assert(cond != nullptr);
-  if (auto mt = cond.getType().dyn_cast<mlir::MemRefType>()) {
+  if (auto mt = llvm::dyn_cast<mlir::MemRefType>(cond.getType())) {
     cond = builder.create<polygeist::Memref2PointerOp>(
         loc,
         LLVM::LLVMPointerType::get(mt.getElementType(),
                                    mt.getMemorySpaceAsInt()),
         cond);
   }
-  if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  if (auto LT = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(cond.getType())) {
     auto nullptr_llvm = builder.create<mlir::LLVM::ZeroOp>(loc, LT);
     cond = builder.create<mlir::LLVM::ICmpOp>(
         loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
@@ -4507,7 +4507,7 @@ MLIRScanner::VisitConditionalOperator(clang::ConditionalOperator *E) {
       truev = trueExpr.val;
     } else {
       if (trueExpr.isReference)
-        if (auto mt = trueExpr.val.getType().dyn_cast<MemRefType>())
+        if (auto mt = llvm::dyn_cast<MemRefType>(trueExpr.val.getType()))
           if (mt.getShape().size() != 1) {
             E->dump();
             E->getTrueExpr()->dump();
@@ -5107,7 +5107,7 @@ MLIRASTConsumer::GetOrCreateMLIRFunction(const FunctionDecl *FD,
 
       bool isArray = false; // isa<clang::ArrayType>(CC->getThisType());
       getMLIRType(CC->getThisObjectType(), &isArray);
-      if (auto mt = t.dyn_cast<MemRefType>()) {
+      if (auto mt = llvm::dyn_cast<MemRefType>(t)) {
         auto shape = std::vector<int64_t>(mt.getShape());
         // shape[0] = 1;
         t = mlir::MemRefType::get(shape, mt.getElementType(),
@@ -5513,7 +5513,7 @@ mlir::Type MLIRASTConsumer::getMLIRType(clang::QualType qt, bool *implicitRef,
       }
 
       // If -memref-fullrank is unset or it cannot be fulfilled.
-      auto mt = mlirty.dyn_cast<MemRefType>();
+      auto mt = llvm::dyn_cast<MemRefType>(mlirty);
       auto shape2 = std::vector<int64_t>(mt.getShape());
       shape2[0] = ShapedType::kDynamic;
       return mlir::MemRefType::get(shape2, mt.getElementType(),

--- a/tools/polymer/lib/Target/OpenScop/ConvertFromOpenScop.cc
+++ b/tools/polymer/lib/Target/OpenScop/ConvertFromOpenScop.cc
@@ -641,7 +641,7 @@ void Importer::initializeSymbol(mlir::Value val) {
 
   /// Symbols that are the block arguments won't be taken care of at this stage.
   /// initializeFuncOpInterface() should already have done that.
-  if (mlir::BlockArgument arg = val.dyn_cast<mlir::BlockArgument>())
+  if (mlir::BlockArgument arg = llvm::dyn_cast<mlir::BlockArgument>(val))
     return;
 
   // This defOp should be cloned to the target function, while its operands

--- a/tools/polymer/lib/Transforms/LoopAnnotate.cc
+++ b/tools/polymer/lib/Transforms/LoopAnnotate.cc
@@ -36,7 +36,7 @@ using namespace polymer;
 static void annotatePointLoops(ValueRange operands, OpBuilder &b) {
   for (mlir::Value operand : operands) {
     // If a loop IV is directly passed into the statement call.
-    if (BlockArgument arg = operand.dyn_cast<BlockArgument>()) {
+    if (BlockArgument arg = llvm::dyn_cast<BlockArgument>(operand)) {
       mlir::affine::AffineForOp forOp =
           dyn_cast<mlir::affine::AffineForOp>(arg.getOwner()->getParentOp());
       if (forOp) {

--- a/tools/polymer/lib/Transforms/LoopExtract.cc
+++ b/tools/polymer/lib/Transforms/LoopExtract.cc
@@ -58,7 +58,7 @@ static void getArgs(Operation *parentOp, llvm::SetVector<Value> &args) {
       if (Operation *defOp = operand.getDefiningOp()) {
         if (!internalOps.contains(defOp))
           args.insert(operand);
-      } else if (BlockArgument bArg = operand.dyn_cast<BlockArgument>()) {
+      } else if (BlockArgument bArg = llvm::dyn_cast<BlockArgument>(operand)) {
         if (!internalOps.contains(bArg.getOwner()->getParentOp()))
           args.insert(operand);
       } else {

--- a/tools/polymer/lib/Transforms/PlutoTransform.cc
+++ b/tools/polymer/lib/Transforms/PlutoTransform.cc
@@ -281,7 +281,7 @@ static void dedupIndexCast(func::FuncOp f) {
   SmallVector<Operation *> toErase;
   for (auto &op : entry) {
     if (auto indexCast = dyn_cast<arith::IndexCastOp>(&op)) {
-      auto arg = indexCast.getOperand().dyn_cast<BlockArgument>();
+      auto arg = llvm::dyn_cast<BlockArgument>(indexCast.getOperand());
       if (argToCast.count(arg)) {
         LLVM_DEBUG(dbgs() << "Found duplicated index_cast: " << indexCast
                           << '\n');

--- a/tools/polymer/lib/Transforms/Reg2Mem.cc
+++ b/tools/polymer/lib/Transforms/Reg2Mem.cc
@@ -210,7 +210,7 @@ static void demoteRegisterToMemory(mlir::func::FuncOp f, OpBuilder &b) {
 
     // Create the alloca op for the scratchpad.
     memref::AllocaOp allocaOp = createScratchpadAllocaOp(
-        val.dyn_cast<mlir::OpResult>(), b, &entryBlock);
+        llvm::dyn_cast<mlir::OpResult>(val), b, &entryBlock);
 
     // Create the store op that stores val into the scratchpad for future uses.
     createScratchpadStoreOp(val, allocaOp, b);

--- a/tools/polymer/lib/Transforms/ScopStmtOpt.cc
+++ b/tools/polymer/lib/Transforms/ScopStmtOpt.cc
@@ -370,7 +370,7 @@ struct RewriteScratchpadTypePass
       // All the operands that are unranked memrefs.
       SmallVector<Value> unranked;
       for (auto operand : caller.getArgOperands())
-        if (MemRefType type = operand.getType().dyn_cast<MemRefType>())
+        if (MemRefType type = llvm::dyn_cast<MemRefType>(operand.getType()))
           if (!type.hasStaticShape())
             unranked.push_back(operand);
       if (unranked.empty())


### PR DESCRIPTION
I tried building this with a more recent llvm commit, and saw all these deprecation warnings. Thought as a test PR I could migrate some of them. Note I couldn't migrate all of them without bumping the commit because dyn_cast is not supported for `Affine*Expr` at the current pinned commit.