### PR TITLE
WIP: Fix char declarations

### DIFF
--- a/tools/cgeist/Test/Verification/char.c
+++ b/tools/cgeist/Test/Verification/char.c
@@ -1,0 +1,13 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+
+char add_one(char x) {
+  char one = 1;
+  return x + one;
+}
+
+// CHECK-LABEL:   func.func @add_one(
+// CHECK-SAME:     %[[x:.*]]: i8) -> i8
+// CHECK-NEXT:       %[[c1:.*]] = arith.constant 1
+// CHECK-NEXT:       %[[res:.*]] = arith.addi %[[x]], %[[c1]] : i8
+// CHECK-NEXT:       return %[[res]] : i8
+// CHECK:         }


### PR DESCRIPTION
Draft. Working notes:

The AST is

```
CompoundStmt 0x5621e73b38c0
|-DeclStmt 0x5621e73b37c0
| `-VarDecl 0x5621e73b3720  used one 'char' cinit
|   `-ImplicitCastExpr 0x5621e73b37a8 'char' <IntegralCast>
|     `-IntegerLiteral 0x5621e73b3788 'int' 1
`-ReturnStmt 0x5621e73b38b0
  `-ImplicitCastExpr 0x5621e73b3898 'char' <IntegralCast>
    `-BinaryOperator 0x5621e73b3878 'int' '+'
      |-ImplicitCastExpr 0x5621e73b3830 'int' <IntegralCast>
      | `-ImplicitCastExpr 0x5621e73b3818 'char' <LValueToRValue>
      |   `-DeclRefExpr 0x5621e73b37d8 'char' lvalue ParmVar 0x5621e73b3550 'x' 'char'
      `-ImplicitCastExpr 0x5621e73b3860 'int' <IntegralCast>
        `-ImplicitCastExpr 0x5621e73b3848 'char' <LValueToRValue>
          `-DeclRefExpr 0x5621e73b37f8 'char' lvalue Var 0x5621e73b3720 'one' 'char'
```

Looks like the right place to fix this is in `MLIRASTConsumer::getMLIRType` in `tools/cgeist/Lib/clang-mlir.cc:5825` where it parses the integer type.

Either that or add a separate visitor for `ImplicitCastExpr` and trunc the `arith.constant` to the size of the `VarDecl`.