### PR TITLE
Add missing dependencies from check-polygeist-opt to FileCheck and not

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_lit_site_cfg(
 
 add_lit_testsuite(check-polygeist-opt "Verify Polygeist passes perform correctly"
     ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS polygeist-opt
+    DEPENDS polygeist-opt FileCheck not
     ARGS -v
 )
 


### PR DESCRIPTION
The invocation of the build target `check-polygeist-opt` in a fresh unified build of LLVM, MLIR, Clang, and Polygeist fails due to the absence of the test utilities `FileCheck` and `not`.

This commit adds dependencies to the utilities, such that the test succeeds even when the utilities have not been built manually.