### PR TITLE
Polygeist Ops Inlining and printing debug info

### DIFF
--- a/lib/polygeist/Dialect.cpp
+++ b/lib/polygeist/Dialect.cpp
@@ -9,6 +9,7 @@
 #include "polygeist/Dialect.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "polygeist/Ops.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 using namespace mlir;
 using namespace mlir::polygeist;
@@ -17,11 +18,25 @@ using namespace mlir::polygeist;
 // Polygeist dialect.
 //===----------------------------------------------------------------------===//
 
+namespace {
+/// This class defines the interface for handling inlining for Polygeist
+/// dialect operations.
+struct PolygeistInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All Polygeist dialect ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
 void PolygeistDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "polygeist/PolygeistOps.cpp.inc"
       >();
+  addInterfaces<PolygeistInlinerInterface>();
 }
 
 #include "polygeist/PolygeistOpsDialect.cpp.inc"

--- a/tools/cgeist/driver.cc
+++ b/tools/cgeist/driver.cc
@@ -612,7 +612,7 @@ int main(int argc, char **argv) {
 
   OpPrintingFlags flags;
   if (PrintDebugInfo)
-    flags.enableDebugInfo(/*pretty*/ false);
+    flags.enableDebugInfo(/*enable*/ true, /*pretty*/ false);
 
   if (ImmediateMLIR) {
     module->print(llvm::outs(), flags);


### PR DESCRIPTION
Allow Polygeist Ops to be inlined and fix a bug regarding printing debug info for cgeist